### PR TITLE
op-guide: update TiKV command flags.

### DIFF
--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -55,10 +55,9 @@ cd tidb-latest-linux-amd64-centos6
 2. 启动 TiKV.
 
     ```bash
-    ./bin/tikv-server -I 1 \
-                      -S raftkv \
+    ./bin/tikv-server --cluster-id 1 \
                       --pd 127.0.0.1:2379 \
-                      -s tikv
+                      --store tikv
     ```
 
 3. 启动 TiDB.
@@ -116,23 +115,20 @@ cd tidb-latest-linux-amd64-centos6
 2. 在每个节点启动 TiKV.
 
     ```bash
-    ./bin/tikv-server -S raftkv \
-                      -I 1 \
+    ./bin/tikv-server --cluster-id 1 \
                       --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
                       --addr 192.168.199.113:20160 \
-                      -s tikv1
+                      --store tikv1
     
-    ./bin/tikv-server -S raftkv \
-                      -I 1 \
+    ./bin/tikv-server --cluster-id 1 \
                       --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
                       --addr 192.168.199.114:20160 \
-                      -s tikv2
+                      --store tikv2
                 
-    ./bin/tikv-server -S raftkv \
-                      -I 1 \
+    ./bin/tikv-server --cluster-id 1 \
                       --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
                       --addr 192.168.199.115:20160 \
-                      -s tikv3
+                      --store tikv3
     ```
 
 3. 在 node1 启动 TiDB.

--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -55,9 +55,9 @@ cd tidb-latest-linux-amd64-centos6
 2. 启动 TiKV.
 
     ```bash
-    ./bin/tikv-server --cluster-id 1 \
-                      --pd 127.0.0.1:2379 \
-                      --store tikv
+    ./bin/tikv-server --cluster-id=1 \
+                      --pd="127.0.0.1:2379" \
+                      --store=tikv
     ```
 
 3. 启动 TiDB.
@@ -115,20 +115,20 @@ cd tidb-latest-linux-amd64-centos6
 2. 在每个节点启动 TiKV.
 
     ```bash
-    ./bin/tikv-server --cluster-id 1 \
-                      --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
-                      --addr 192.168.199.113:20160 \
-                      --store tikv1
+    ./bin/tikv-server --cluster-id=1 \
+                      --pd="192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379" \
+                      --addr="192.168.199.113:20160" \
+                      --store=tikv1
     
-    ./bin/tikv-server --cluster-id 1 \
-                      --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
-                      --addr 192.168.199.114:20160 \
-                      --store tikv2
+    ./bin/tikv-server --cluster-id=1 \
+                      --pd="192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379" \
+                      --addr="192.168.199.114:20160" \
+                      --store=tikv2
                 
-    ./bin/tikv-server --cluster-id 1 \
-                      --pd 192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379 \
-                      --addr 192.168.199.115:20160 \
-                      --store tikv3
+    ./bin/tikv-server --cluster-id=1 \
+                      --pd="192.168.199.113:2379,192.168.199.114:2379,192.168.199.115:2379" \
+                      --addr="192.168.199.115:20160" \
+                      --store=tikv3
     ```
 
 3. 在 node1 启动 TiDB.

--- a/op-guide/docker-compose.md
+++ b/op-guide/docker-compose.md
@@ -74,7 +74,6 @@ services:
       - --cluster-id=1
       - --addr=0.0.0.0:20160
       - --advertise-addr=tikv1:20160
-      - --dsn=raftkv
       - --store=/var/tikv
       - --pd=pd1:2379,pd2:2379,pd3:2379
 
@@ -98,7 +97,6 @@ services:
       - --cluster-id=1
       - --addr=0.0.0.0:20160
       - --advertise-addr=tikv2:20160
-      - --dsn=raftkv
       - --store=/var/tikv
       - --pd=pd1:2379,pd2:2379,pd3:2379
 
@@ -122,7 +120,6 @@ services:
       - --cluster-id=1
       - --addr=0.0.0.0:20160
       - --advertise-addr=tikv3:20160
-      - --dsn=raftkv
       - --store=/var/tikv
       - --pd=pd1:2379,pd2:2379,pd3:2379
 

--- a/op-guide/docker-deployment.md
+++ b/op-guide/docker-deployment.md
@@ -116,7 +116,6 @@ docker run -d --name tikv1 \
   --addr="0.0.0.0:20160" \
   --advertise-addr="${host1}:20160" \
   --store="/tidata/tikv1" \
-  --dsn=raftkv \
   --pd="${host1}:2379,${host2}:2379,${host3}:2379" \
   --cluster-id=1
 ```
@@ -131,7 +130,6 @@ docker run -d --name tikv2 \
   --addr="0.0.0.0:20160" \
   --advertise-addr="${host2}:20160" \
   --store="/tidata/tikv2" \
-  --dsn=raftkv \
   --pd="${host1}:2379,${host2}:2379,${host3}:2379" \
   --cluster-id=1
 ```
@@ -146,7 +144,6 @@ docker run -d --name tikv3 \
   --addr="0.0.0.0:20160" \
   --advertise-addr="${host3}:20160" \
   --store="/tidata/tikv3" \
-  --dsn=raftkv \
   --pd="${host1}:2379,${host2}:2379,${host3}:2379" \
   --cluster-id=1
 ```


### PR DESCRIPTION
+ Remove the unnecessary `dsn` flag
+ Command line uses long options just like PD and TiDB.

@shenli @queenypingcap @iamxy 