### PR TITLE
Correct the hyper-link address of -config section in binary-deployment.md

### DIFF
--- a/op-guide/binary-deployment.md
+++ b/op-guide/binary-deployment.md
@@ -141,7 +141,7 @@ cd tidb-latest-linux-amd64-centos6
     mysql -h 192.168.199.113 -P 4000 -u root -D test
     ```
 
-> 注意：在生产环境中启动 TiKV 时，建议使用 [\-\-config](op-guide/configuration.md#-c---config) 参数指定配置文件路径，如果不设置这个参数，TiKV 不会读取配置文件。同样，在生产环境中部署 PD 时，也建议使用 [\-\-config](op-guide/configuration.md#--config) 参数指定配置文件路径。
+> 注意：在生产环境中启动 TiKV 时，建议使用 [\-\-config](configuration.md#-c---config) 参数指定配置文件路径，如果不设置这个参数，TiKV 不会读取配置文件。同样，在生产环境中部署 PD 时，也建议使用 [\-\-config](configuration.md#--config) 参数指定配置文件路径。
 > 
 > 注意：如果使用 `nohup` 在生产环境中启动集群，需要将启动命令放到一个脚本文件里面执行，否则会出现因为 Shell 退出导致 `nohup` 启动的进程也收到异常信号退出的问题，具体参考[进程异常退出](../trouble-shooting.md#tidbtikvpd-进程异常退出)。
 


### PR DESCRIPTION
Correct the link address of -config section in binary-deployment.md
In binary-deployment.md file two hyper-links' address has doubled **op_guide**
https://github.com/pingcap/docs-cn/blob/master/op-guide/op-guide/configuration.md#--config