### PR TITLE
fix: remove hardcode 'rc4+' for pdf version

### DIFF
--- a/scripts/generate_pdf.sh
+++ b/scripts/generate_pdf.sh
@@ -17,7 +17,7 @@ pandoc -N --toc --smart --latex-engine=xelatex \
     --listings \
     -V title="TiDB 中文手册" \
     -V author="PingCAP Inc." \
-    -V date="v1.0.0\$\sim\$rc4+${_version_tag}" \
+    -V date="v1.0.0\$\sim\$${_version_tag}" \
     -V CJKmainfont="${MAINFONT}" \
     -V mainfont="${MAINFONT}" \
     -V sansfont="${MAINFONT}" \

--- a/scripts/generate_pdf.sh
+++ b/scripts/generate_pdf.sh
@@ -17,7 +17,7 @@ pandoc -N --toc --smart --latex-engine=xelatex \
     --listings \
     -V title="TiDB 中文手册" \
     -V author="PingCAP Inc." \
-    -V date="v1.0.0\$\sim\$${_version_tag}" \
+    -V date="${_version_tag}" \
     -V CJKmainfont="${MAINFONT}" \
     -V mainfont="${MAINFONT}" \
     -V sansfont="${MAINFONT}" \


### PR DESCRIPTION
Is `v1.0.0~` necessary to keep？
@lilin90 @gaohailang PTAL
