### PR TITLE
op-guide: fix description that does not match

### DIFF
--- a/op-guide/docker-compose.md
+++ b/op-guide/docker-compose.md
@@ -97,7 +97,7 @@ category: deployment
 5. 使用生成的 `docker-compose.yml` 创建并启动集群
 
     ```bash
-    docker-compose -f generated-docker-compose.yaml pull # Get the latest Docker images
+    docker-compose -f generated-docker-compose.yml pull # Get the latest Docker images
     docker-compose -f generated-docker-compose.yml up -d
     ```
 


### PR DESCRIPTION
fix: description does not match, used two different suffix of file generated-docker-compose