### PR TITLE
op-guide: Update pip usage in ansible-deployment.md

### DIFF
--- a/op-guide/ansible-deployment.md
+++ b/op-guide/ansible-deployment.md
@@ -133,7 +133,7 @@ $ git clone https://github.com/pingcap/tidb-ansible.git
 
   ```bash
   $ cd /home/tidb/tidb-ansible
-  $ sudo pip install -r ./requirements.txt
+  $ pip install -r ./requirements.txt --user
   $ ansible --version
     ansible 2.5.0
   ```


### PR DESCRIPTION
It's better to use 
```
pip install --user package
```
To install the package in your home directory avoid using sudo.