### PR TITLE
tispark: fix a broken link caused by a period

### DIFF
--- a/tispark/tispark-quick-start-guide.md
+++ b/tispark/tispark-quick-start-guide.md
@@ -183,4 +183,4 @@ scala> spark.sql(
 -----------------+---------+------------+--------+-----------+
 ```
 
-更多样例请参考 https://github.com/ilovesoup/tpch/tree/master/sparksql。
+更多样例请参考 https://github.com/ilovesoup/tpch/tree/master/sparksql 


### PR DESCRIPTION
句号导致url错误