### PR TITLE
QUICKSTART: fix alter add unique syntax

### DIFF
--- a/try-tidb.md
+++ b/try-tidb.md
@@ -116,7 +116,7 @@ CREATE UNIQUE INDEX person_num ON person (number);
 或者
 
 ```sql
-ALTER TABLE person ADD UNIQUE person_num  on (number);
+ALTER TABLE person ADD UNIQUE person_num (number);
 ```
 
 使用 `SHOW INDEX` 语句查看表内所有索引：

--- a/v1.0/QUICKSTART.md
+++ b/v1.0/QUICKSTART.md
@@ -134,7 +134,7 @@ CREATE UNIQUE INDEX person_num ON person (number);
 或者
 
 ```sql
-ALTER TABLE person ADD UNIQUE person_num  on (number);
+ALTER TABLE person ADD UNIQUE person_num (number);
 ```
 
 使用 `SHOW INDEX` 语句查看表内所有索引：

--- a/v2.0/QUICKSTART.md
+++ b/v2.0/QUICKSTART.md
@@ -134,7 +134,7 @@ CREATE UNIQUE INDEX person_num ON person (number);
 或者
 
 ```sql
-ALTER TABLE person ADD UNIQUE person_num  on (number);
+ALTER TABLE person ADD UNIQUE person_num (number);
 ```
 
 使用 `SHOW INDEX` 语句查看表内所有索引：

--- a/v2.1/try-tidb.md
+++ b/v2.1/try-tidb.md
@@ -116,7 +116,7 @@ CREATE UNIQUE INDEX person_num ON person (number);
 或者
 
 ```sql
-ALTER TABLE person ADD UNIQUE person_num  on (number);
+ALTER TABLE person ADD UNIQUE person_num (number);
 ```
 
 使用 `SHOW INDEX` 语句查看表内所有索引：


### PR DESCRIPTION
Fix the wrong syntax in QUICKSTART from:

```
ALTER TABLE person ADD UNIQUE person_num on (number);
```
to 

```
ALTER TABLE person ADD UNIQUE person_num (number);
```