### PR TITLE
tools/dm: add doc for DM use in shard merge scenario

### DIFF
--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -57,7 +57,7 @@ category: tools
 
 ## 同步方案
 
-- 要满足同步需求 #1 和 #2, 配置[表路由规则](/tools/dm/data-synchronization-features.md#table-routing)如下：
+- 要满足同步需求 #1 和 #2, 配置 [Table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
 
     ```yaml
     routes:
@@ -67,7 +67,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步需求 #3, 配置[表路由规则](/tools/dm/data-synchronization-features.md#table-routing)如下：
+- 要满足同步需求 #3, 配置 [Table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
 
     ```yaml
     routes:
@@ -82,7 +82,7 @@ category: tools
         target-table:  "sale"
     ```
 
-- 要满足同步需求 #4 和 #5, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering)如下：
+- 要满足同步需求 #4 和 #5, 配置 [Binlog event filtering 规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
 
     ```yaml
     filters:
@@ -95,7 +95,7 @@ category: tools
 
     > **注意：** 同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
 
-- 要满足同步需求 #6, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步需求 #6, 配置 [Binlog event filtering 规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
 
     ```yaml
     filters:
@@ -111,7 +111,7 @@ category: tools
         action: Ignore
     ```
 
-- 要满足同步需求 #7, 配置[黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists)如下：
+- 要满足同步需求 #7, 配置 [Black and white table lists](/tools/dm/data-synchronization-features.md#black-and-white-table-lists) 如下：
 
     ```yaml
     black-white-list:
@@ -121,7 +121,7 @@ category: tools
           tbl-name: "log_bak"
     ```
 
-- 要满足同步需求 #8, 配置[列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping)如下：
+- 要满足同步需求 #8, 配置 [Column mapping 规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
 
     ```yaml
     column-mappings:

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -6,7 +6,7 @@ category: tools
 
 # Data Migration 分片合并场景
 
-本文介绍如何在分片合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分片结构和分表数据需要同步至下游 TiDB 集群。
+本文介绍如何在分片合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分库和分表数据需要同步至下游 TiDB 集群。
 
 ## 上游实例
 
@@ -58,7 +58,7 @@ category: tools
 
 ## 同步方案
 
-- 要满足同步需求 #1 和 #2, 配置 [表路由规则](/tools/dm/data-synchronization-features.md#表路由) 如下：
+- 要满足同步需求 #1 和 #2, 配置 [表路由规则](/tools/dm/data-synchronization-features.md##table-routing) 如下：
 
     ```yaml
     routes:
@@ -68,7 +68,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步要求 #3, 配置 [表路由规则](/tools/dm/data-synchronization-features.md#表路由) 如下：
+- 要满足同步要求 #3, 配置 [表路由规则](/tools/dm/data-synchronization-features.md##table-routing) 如下：
 
     ```yaml
     routes:

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -5,7 +5,7 @@ category: tools
 
 # DM 分库分表合并场景
 
-本文介绍如何在分片合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分库和分表数据需要同步至下游 TiDB 集群。
+本文介绍如何在分库分表合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分库和分表数据需要同步至下游 TiDB 集群。
 
 ## 上游实例
 
@@ -42,7 +42,7 @@ category: tools
 3. 合并三个实例中的 `store_{01|02}`.`sale_{01|02}` 表至下游TiDB中的 `store`.`sale` 表。
 4. 过滤掉三个实例的 `user`.`log_{north|south|east}` 表的所有删除操作。
 5. 过滤掉三个实例的 `user`.`information` 表的所有删除操作。
-6. 过滤掉三个实例的 `store_{01|02}`.`sale_{01|02}` 表的所有删除操作
+6. 过滤掉三个实例的 `store_{01|02}`.`sale_{01|02}` 表的所有删除操作。
 7. 过滤掉三个实例的 `user`.`log_bak` 表。
 8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有 bigint 型的自增主键，将其合并至 TiDB 时会引发冲突。您需要有方案修改相应自增主键以避免冲突。
 
@@ -67,7 +67,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步需求 #3, 配置 [Table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
+- 要满足同步需求 #3, 配置 [table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
 
     ```yaml
     routes:
@@ -82,7 +82,7 @@ category: tools
         target-table:  "sale"
     ```
 
-- 要满足同步需求 #4 和 #5, 配置 [Binlog event filtering 规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步需求 #4 和 #5, 配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
 
     ```yaml
     filters:
@@ -95,7 +95,7 @@ category: tools
 
     > **注意：** 同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
 
-- 要满足同步需求 #6, 配置 [Binlog event filtering 规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步需求 #6, 配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
 
     ```yaml
     filters:
@@ -111,7 +111,7 @@ category: tools
         action: Ignore
     ```
 
-- 要满足同步需求 #7, 配置 [Black and white table lists](/tools/dm/data-synchronization-features.md#black-and-white-table-lists) 如下：
+- 要满足同步需求 #7, 配置 [black & white table lists](/tools/dm/data-synchronization-features.md#black-&-white-table-lists) 如下：
 
     ```yaml
     black-white-list:
@@ -121,7 +121,7 @@ category: tools
           tbl-name: "log_bak"
     ```
 
-- 要满足同步需求 #8, 配置 [Column mapping 规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
+- 要满足同步需求 #8, 配置 [column mapping 规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
 
     ```yaml
     column-mappings:

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -93,7 +93,7 @@ category: tools
         action: Ignore
     ```
 
-    > **注意：** 同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
+    > **注意**：同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
 
 - 要满足同步需求 #6，配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
 

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -57,7 +57,7 @@ category: tools
 
 ## 同步方案
 
-- 要满足同步需求 #1 和 #2, 配置 [Table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
+- 要满足同步需求 #1 和 #2，配置 [Table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
 
     ```yaml
     routes:
@@ -67,7 +67,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步需求 #3, 配置 [table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
+- 要满足同步需求 #3，配置 [table routing 规则](/tools/dm/data-synchronization-features.md#table-routing) 如下：
 
     ```yaml
     routes:
@@ -82,7 +82,7 @@ category: tools
         target-table:  "sale"
     ```
 
-- 要满足同步需求 #4 和 #5, 配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
+- 要满足同步需求 #4 和 #5，配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
 
     ```yaml
     filters:
@@ -95,7 +95,7 @@ category: tools
 
     > **注意：** 同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
 
-- 要满足同步需求 #6, 配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
+- 要满足同步需求 #6，配置 [Binlog event filter 规则](/tools/dm/data-synchronization-features.md#binlog-event-filter) 如下：
 
     ```yaml
     filters:
@@ -111,7 +111,7 @@ category: tools
         action: Ignore
     ```
 
-- 要满足同步需求 #7, 配置 [black & white table lists](/tools/dm/data-synchronization-features.md#black-&-white-table-lists) 如下：
+- 要满足同步需求 #7，配置 [black & white table lists](/tools/dm/data-synchronization-features.md#black-&-white-table-lists) 如下：
 
     ```yaml
     black-white-list:
@@ -121,7 +121,7 @@ category: tools
           tbl-name: "log_bak"
     ```
 
-- 要满足同步需求 #8, 配置 [column mapping 规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
+- 要满足同步需求 #8，配置 [column mapping 规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
 
     ```yaml
     column-mappings:

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -1,10 +1,10 @@
 ---
-title: DM 分片合并场景
-summary: 学习分片合并场景下如何使用 DM 同步数据
+title: DM 分库分表合并场景
+summary: 学习分库分表合并场景下如何使用 DM 同步数据
 category: tools
 ---
 
-# Data Migration 分片合并场景
+# DM 分库分表合并场景
 
 本文介绍如何在分片合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分库和分表数据需要同步至下游 TiDB 集群。
 
@@ -14,7 +14,7 @@ category: tools
 
 - 实例 1
 
-    | 库 | 表 |
+    | Schema | Tables |
     |:------|:------|
     | user  | information, log_north, log_bak |
     | store_01 | sale_01, sale_02 |
@@ -22,7 +22,7 @@ category: tools
 
 - 实例 2
 
-    | 库 | 表 |
+    | Schema | Tables |
     |:------|:------|
     | user  | information, log_east, log_bak |
     | store_01 | sale_01, sale_02 |
@@ -30,7 +30,7 @@ category: tools
 
 - 实例 3
 
-    | 库 | 表 |
+    | Schema | Tables |
     |:------|:------|
     | user  | information, log_south, log_bak |
     | store_01 | sale_01, sale_02 |
@@ -45,13 +45,13 @@ category: tools
 5. 过滤掉三个实例的 `user`.`information` 表的所有删除操作。
 6. 过滤掉三个实例的 `store_{01|02}`.`sale_{01|02}` 表的所有删除操作
 7. 过滤掉三个实例的 `user`.`log_bak` 表。
-8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有 bigint 型的自增主键，将其合并至 TiDB 时会引发冲突。您需要修改相应自增主键以避免冲突。
+8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有 bigint 型的自增主键，将其合并至 TiDB 时会引发冲突。您需要有方案修改相应自增主键以避免冲突。
 
 ## 下游实例
 
 假设同步后下游库结构如下：
 
-| 库 | 表 |
+| Schema | Tables |
 |:------|:------|
 | user | information, log_north, log_east, log_south|
 | store | sale |

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -1,0 +1,273 @@
+---
+title: DM 分片合并场景
+summary: 学习分片合并场景下如何使用 DM 同步数据
+category: tools
+---
+
+# Data Migration 分片合并场景
+
+本文介绍如何在分片合并场景中使用 Data Migration (DM)。使用场景中，三个上游 MySQL 实例的分片结构和分表数据需要同步至下游 TiDB 集群。
+
+## 上游实例
+
+假设上游库结构如下：
+
+- 实例 1
+
+    | 库 | 表 |
+    |:------|:------|
+    | user  | information, log_north, log_bak |
+    | store_01 | sale_01, sale_02 |
+    | store_02 | sale_01, sale_02 |
+
+- 实例 2
+
+    | 库 | 表 |
+    |:------|:------|
+    | user  | information, log_east, log_bak |
+    | store_01 | sale_01, sale_02 |
+    | store_02 | sale_01, sale_02 |
+
+- 实例 3
+
+    | 库 | 表 |
+    |:------|:------|
+    | user  | information, log_south, log_bak |
+    | store_01 | sale_01, sale_02 |
+    | store_02 | sale_01, sale_02 |
+
+## 同步需求
+
+1. 合并三个上游实例中的 `user`.`information` 表至下游 TiDB 中的 `user`.`information` 表。
+2. 合并三个上游实例中的 `user`.`log_{north|south|east}` 表至下游TiDB中的 `user`.`log_{north|south|east}` 表。
+3. 合并三个上游实例中的 `store_{01|02}`.`sale_{01|02}` 表至下游TiDB中的 `store`.`sale` 表。
+4. 从三个上游实例中的 `user`.`log_{north|south|east}` 表中过滤掉所有删除操作。
+5. 从三个上游实例中的 `user`.`information` 表中过滤掉所有删除操作。
+6. 从三个上游实例中的  `store_{01|02}`.`sale_{01|02}` 表中过滤掉所有删除操作。
+7. 过滤掉三个上游实例中的 `user`.`log_bak` 表。
+8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有长整型的自增主键，将这些表合并至 TiDB 时会引发合并冲突。您需要修改相应自增主键以避免冲突。
+
+## 下游实例
+
+假设同步后下游库结构如下：
+
+| 库 | 表 |
+|:------|:------|
+| user | information, log_north, log_east, log_south|
+| store | sale |
+
+## 同步方案
+
+- 要满足同步需求 #1 和 #2, 配置 [表路由规则](/tools/dm/data-synchronization-features.md#表路由) 如下：
+
+    ```yaml
+    routes:
+      ...
+      user-route-rule:
+        schema-pattern: "user"
+        target-schema: "user"
+    ```
+
+- 要满足同步要求 #3, 配置 [表路由规则](/tools/dm/data-synchronization-features.md#表路由) 如下：
+
+    ```yaml
+    routes:
+      ...
+      store-route-rule:
+        schema-pattern: "store_*"
+        target-schema: "store"
+      sale-route-rule:
+        schema-pattern: "store_*"
+        table-pattern: "sale_*"
+        target-schema: "store"
+        target-table:  "sale"
+    ```
+
+- 要满足同步要求 #4 和 #5, 配置 [binlog 事件过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+
+    ```yaml
+    filters:
+      ...
+      user-filter-rule:
+        schema-pattern: "user"
+        events: ["truncate table", "drop table", "delete"， "drop database"]
+        action: Ignore
+    ```
+
+    > **注意：** 同步要求 #4、#5 和 #7 中，所有对 `user` 库的删除操作都要被过滤，所以此处配置了库级别的过滤规则。但需要注意的是，`user` 库将来出现表的删除操作也都会被过滤。
+
+- 要满足同步要求 #6, 配置 [binlog 事件过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+
+    ```yaml
+    filters:
+      ...
+      sale-filter-rule:
+        schema-pattern: "store_*"
+        table-pattern: "sale_*"
+        events: ["truncate table", "drop table", "delete"]
+        action: Ignore
+      store-filter-rule:
+        schema-pattern: "store_*"
+        events: ["drop database"]
+        action: Ignore
+    ```
+
+- 要满足同步要求 #7, 配置 [黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists) 如下：
+
+    ```yaml
+    black-white-list:
+      log-bak-ignored:
+        ignore-tales:
+        - db-name: "user"
+          tbl-name: "log_bak"
+    ```
+
+- 要满足同步要求 #8, 配置 [列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
+
+    ```yaml
+    column-mappings:
+      instance-1-sale:
+        schema-pattern: "store_*"
+        table-pattern: "sale_*"
+        expression: "partition id"
+        source-column: "id"
+        target-column: "id"
+        arguments: ["1", "store_", "sale_"]
+      instance-2-sale:
+        schema-pattern: "store_*"
+        table-pattern: "sale_*"
+        expression: "partition id"
+        source-column: "id"
+        target-column: "id"
+        arguments: ["2", "store_", "sale_"]
+      instance-3-sale:
+        schema-pattern: "store_*"
+        table-pattern: "sale_*"
+        expression: "partition id"
+        source-column: "id"
+        target-column: "id"
+        arguments: ["3", "store_", "sale_"]
+    ```
+
+## 同步任务配置
+
+同步任务的完整配置如下。更多信息，请参考 [Data Migration 任务配置文件](/tools/dm/task-configuration-file-intro.md).
+
+```yaml
+name: "shard_merge"
+task-mode: all
+meta-schema: "dm_meta"
+remove-meta: false
+
+target-database:
+  host: "192.168.0.1"
+  port: 4000
+  user: "root"
+  password: ""
+
+mysql-instances:
+  -
+    source-id: "instance-1"
+    route-rules: ["user-route-rule", "store-route-rule", "sale-route-rule"]
+    filter-rules: ["user-filter-rule", "store-filter-rule" , "sale-filter-rule"]
+    column-mapping-rules: ["instance-1-sale"]
+    black-white-list:  "log-bak-ignored"
+    mydumper-config-name: "global"
+    loader-config-name: "global"
+    syncer-config-name: "global"
+
+  -
+    source-id: "instance-2"
+    route-rules: ["user-route-rule", "store-route-rule", "sale-route-rule"]
+    filter-rules: ["user-filter-rule", "store-filter-rule" , "sale-filter-rule"]
+    column-mapping-rules: ["instance-2-sale"]
+    black-white-list:  "log-bak-ignored"
+    mydumper-config-name: "global"
+    loader-config-name: "global"
+    syncer-config-name: "global"
+  -
+    source-id: "instance-3"
+    route-rules: ["user-route-rule", "store-route-rule", "sale-route-rule"]
+    filter-rules: ["user-filter-rule", "store-filter-rule" , "sale-filter-rule"]
+    column-mapping-rules: ["instance-3-sale"]
+    black-white-list:  "log-bak-ignored"
+    mydumper-config-name: "global"
+    loader-config-name: "global"
+    syncer-config-name: "global"
+
+# 所有实例共享的其他通用配置
+
+routes:
+  user-route-rule:
+    schema-pattern: "user"
+    target-schema: "user"
+  store-route-rule:
+    schema-pattern: "store_*"
+    target-schema: "store"
+  sale-route-rule:
+    schema-pattern: "store_*"
+    table-pattern: "sale_*"
+    target-schema: "store"
+    target-table:  "sale"
+
+filters:
+  user-filter-rule:
+    schema-pattern: "user"
+    events: ["truncate table", "drop table", "delete"， "drop database"]
+    action: Ignore
+  sale-filter-rule:
+    schema-pattern: "store_*"
+    table-pattern: "sale_*"
+    events: ["truncate table", "drop table", "delete"]
+    action: Ignore
+  store-filter-rule:
+    schema-pattern: "store_*"
+    events: ["drop database"]
+    action: Ignore
+
+black-white-list:
+  log-bak-ignored:
+    ignore-tales:
+    - db-name: "user"
+      tbl-name: "log_bak"
+
+column-mappings:
+  instance-1-sale:
+    schema-pattern: "store_*"
+    table-pattern: "sale_*"
+    expression: "partition id"
+    source-column: "id"
+    target-column: "id"
+    arguments: ["1", "store_", "sale_"]
+  instance-2-sale:
+    schema-pattern: "store_*"
+    table-pattern: "sale_*"
+    expression: "partition id"
+    source-column: "id"
+    target-column: "id"
+    arguments: ["2", "store_", "sale_"]
+  instance-3-sale:
+    schema-pattern: "store_*"
+    table-pattern: "sale_*"
+    expression: "partition id"
+    source-column: "id"
+    target-column: "id"
+    arguments: ["3", "store_", "sale_"]
+
+mydumpers:
+  global:
+    threads: 4
+    chunk-filesize: 64
+    skip-tz-utc: true
+
+loaders:
+  global:
+    pool-size: 16
+    dir: "./dumped_data"
+
+syncers:
+  global:
+    worker-count: 16
+    batch: 100
+    max-retry: 100
+```

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -1,6 +1,5 @@
 ---
 title: DM 分库分表合并场景
-summary: 学习分库分表合并场景下如何使用 DM 同步数据
 category: tools
 ---
 
@@ -151,7 +150,7 @@ category: tools
 
 ## 同步任务配置
 
-同步任务的完整配置如下。更多信息，请参考 [Data Migration 任务配置文件](/tools/dm/task-configuration-file-intro.md).
+同步任务的完整配置如下。详情请参阅 [Data Migration 任务配置文件](/tools/dm/task-configuration-file-intro.md)。
 
 ```yaml
 name: "shard_merge"

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -58,7 +58,7 @@ category: tools
 
 ## 同步方案
 
-- 要满足同步需求 #1 和 #2, 配置 [表路由规则](/tools/dm/data-synchronization-features.md##table-routing) 如下：
+- 要满足同步需求 #1 和 #2, 配置[表路由规则](/tools/dm/data-synchronization-features.md##table-routing)如下：
 
     ```yaml
     routes:
@@ -68,7 +68,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步要求 #3, 配置 [表路由规则](/tools/dm/data-synchronization-features.md##table-routing) 如下：
+- 要满足同步要求 #3, 配置[表路由规则](/tools/dm/data-synchronization-features.md##table-routing)如下：
 
     ```yaml
     routes:
@@ -83,7 +83,7 @@ category: tools
         target-table:  "sale"
     ```
 
-- 要满足同步要求 #4 和 #5, 配置 [binlog 事件过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步要求 #4 和 #5, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering)如下：
 
     ```yaml
     filters:
@@ -96,7 +96,7 @@ category: tools
 
     > **注意：** 同步要求 #4、#5 和 #7 中，所有对 `user` 库的删除操作都要被过滤，所以此处配置了库级别的过滤规则。但需要注意的是，`user` 库将来出现表的删除操作也都会被过滤。
 
-- 要满足同步要求 #6, 配置 [binlog 事件过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步要求 #6, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
 
     ```yaml
     filters:
@@ -112,7 +112,7 @@ category: tools
         action: Ignore
     ```
 
-- 要满足同步要求 #7, 配置 [黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists) 如下：
+- 要满足同步要求 #7, 配置[黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists)如下：
 
     ```yaml
     black-white-list:
@@ -122,7 +122,7 @@ category: tools
           tbl-name: "log_bak"
     ```
 
-- 要满足同步要求 #8, 配置 [列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping) 如下：
+- 要满足同步要求 #8, 配置[列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping)如下：
 
     ```yaml
     column-mappings:

--- a/tools/dm/shard-merge-scenario.md
+++ b/tools/dm/shard-merge-scenario.md
@@ -38,14 +38,14 @@ category: tools
 
 ## 同步需求
 
-1. 合并三个上游实例中的 `user`.`information` 表至下游 TiDB 中的 `user`.`information` 表。
-2. 合并三个上游实例中的 `user`.`log_{north|south|east}` 表至下游TiDB中的 `user`.`log_{north|south|east}` 表。
-3. 合并三个上游实例中的 `store_{01|02}`.`sale_{01|02}` 表至下游TiDB中的 `store`.`sale` 表。
-4. 从三个上游实例中的 `user`.`log_{north|south|east}` 表中过滤掉所有删除操作。
-5. 从三个上游实例中的 `user`.`information` 表中过滤掉所有删除操作。
-6. 从三个上游实例中的  `store_{01|02}`.`sale_{01|02}` 表中过滤掉所有删除操作。
-7. 过滤掉三个上游实例中的 `user`.`log_bak` 表。
-8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有长整型的自增主键，将这些表合并至 TiDB 时会引发合并冲突。您需要修改相应自增主键以避免冲突。
+1. 合并三个实例中的 `user`.`information` 表至下游 TiDB 中的 `user`.`information` 表。
+2. 合并三个实例中的 `user`.`log_{north|south|east}` 表至下游TiDB中的 `user`.`log_{north|south|east}` 表。
+3. 合并三个实例中的 `store_{01|02}`.`sale_{01|02}` 表至下游TiDB中的 `store`.`sale` 表。
+4. 过滤掉三个实例的 `user`.`log_{north|south|east}` 表的所有删除操作。
+5. 过滤掉三个实例的 `user`.`information` 表的所有删除操作。
+6. 过滤掉三个实例的 `store_{01|02}`.`sale_{01|02}` 表的所有删除操作
+7. 过滤掉三个实例的 `user`.`log_bak` 表。
+8. 因为 `store_{01|02}`.`sale_{01|02}` 表带有 bigint 型的自增主键，将其合并至 TiDB 时会引发冲突。您需要修改相应自增主键以避免冲突。
 
 ## 下游实例
 
@@ -58,7 +58,7 @@ category: tools
 
 ## 同步方案
 
-- 要满足同步需求 #1 和 #2, 配置[表路由规则](/tools/dm/data-synchronization-features.md##table-routing)如下：
+- 要满足同步需求 #1 和 #2, 配置[表路由规则](/tools/dm/data-synchronization-features.md#table-routing)如下：
 
     ```yaml
     routes:
@@ -68,7 +68,7 @@ category: tools
         target-schema: "user"
     ```
 
-- 要满足同步要求 #3, 配置[表路由规则](/tools/dm/data-synchronization-features.md##table-routing)如下：
+- 要满足同步需求 #3, 配置[表路由规则](/tools/dm/data-synchronization-features.md#table-routing)如下：
 
     ```yaml
     routes:
@@ -83,7 +83,7 @@ category: tools
         target-table:  "sale"
     ```
 
-- 要满足同步要求 #4 和 #5, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering)如下：
+- 要满足同步需求 #4 和 #5, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering)如下：
 
     ```yaml
     filters:
@@ -94,9 +94,9 @@ category: tools
         action: Ignore
     ```
 
-    > **注意：** 同步要求 #4、#5 和 #7 中，所有对 `user` 库的删除操作都要被过滤，所以此处配置了库级别的过滤规则。但需要注意的是，`user` 库将来出现表的删除操作也都会被过滤。
+    > **注意：** 同步需求 #4、#5 和 #7 的操作意味着过滤掉所有对 `user` 库的删除操作，所以此处配置了库级别的过滤规则。但是 `user` 库以后加入表的删除操作也都会被过滤。
 
-- 要满足同步要求 #6, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
+- 要满足同步需求 #6, 配置 [binlog event 过滤规则](/tools/dm/data-synchronization-features.md#binlog-event-filtering) 如下：
 
     ```yaml
     filters:
@@ -112,7 +112,7 @@ category: tools
         action: Ignore
     ```
 
-- 要满足同步要求 #7, 配置[黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists)如下：
+- 要满足同步需求 #7, 配置[黑白表名单](/tools/dm/data-synchronization-features.md#black-and-white-table-lists)如下：
 
     ```yaml
     black-white-list:
@@ -122,7 +122,7 @@ category: tools
           tbl-name: "log_bak"
     ```
 
-- 要满足同步要求 #8, 配置[列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping)如下：
+- 要满足同步需求 #8, 配置[列值转换规则](/tools/dm/data-synchronization-features.md#column-mapping)如下：
 
     ```yaml
     column-mappings:


### PR DESCRIPTION
Added doc for DM use in shard merge scenario. The corresponding source file in English is:https://github.com/pingcap/docs/blob/master/tools/dm/shard-merge-scenario.md

@lilin90 @GregoryIan  PTAL

There are 4 external links included in this file, which are to be consistent with **data-synchronization-features.md** to be done by @GregoryIan 

/tools/dm/data-synchronization-features.md##table-routing
/tools/dm/data-synchronization-features.md#binlog-event-filtering
/tools/dm/data-synchronization-features.md#black-and-white-table-lists
/tools/dm/data-synchronization-features.md#column-mapping

