### PR TITLE
tools/dm: add SQL unsupported by TiDB parser

### DIFF
--- a/tools/dm/data-synchronization-features.md
+++ b/tools/dm/data-synchronization-features.md
@@ -305,17 +305,14 @@ filters:
 
 #### 过滤 TiDB 不支持的 SQL 语句
 
-对于 TiDB parser 不支持的 SQL 语句，DM 无法解析获得 `schema`/`table` 信息，因此需要使用全局过滤规则（`schema-pattern: "*"`）。
-
-> **注意**：全局过滤规则的设置必须尽可能地严格，以避免不合预期地过滤需要同步的数据。
-
-设置下面的规则过滤 TiDB parser 不支持的 `PARTITION statement`：
+可设置如下规则过滤 TiDB 不支持的 `PROCEDURE` 语句：
 
 ```yaml
 filters:
-  filter-partition-rule:
-    schema-pattern: "*"
-    sql-pattern: ["ALTER\\s+TABLE[\\s\\S]*ADD\\s+PARTITION", "ALTER\\s+TABLE[\\s\\S]*DROP\\s+PARTITION"]
+  filter-procedure-rule:
+    schema-pattern: "test_*"
+    table-pattern: "t_*"
+    sql-pattern: ["^DROP\\s+PROCEDURE", "^CREATE\\s+PROCEDURE"]
     action: Ignore
 ```
 

--- a/tools/dm/data-synchronization-features.md
+++ b/tools/dm/data-synchronization-features.md
@@ -319,6 +319,22 @@ filters:
     action: Ignore
 ```
 
+#### 过滤 TiDB parser 不支持的 SQL 语句
+
+对于 TiDB parser 不支持的 SQL 语句，DM 无法解析获得 `schema`/`table` 信息，因此需要使用全局过滤规则：`schema-pattern: "*"`。
+
+> **注意**：全局过滤规则的设置必须尽可能严格，以避免预期之外地过滤掉需要同步的数据。
+
+可设置如下规则过滤 TiDB parser 不支持的 `PARTITION` 语句：
+
+```yaml
+filters:
+  filter-partition-rule:
+    schema-pattern: "*"
+    sql-pattern: ["ALTER\\s+TABLE[\\s\\S]*ADD\\s+PARTITION", "ALTER\\s+TABLE[\\s\\S]*DROP\\s+PARTITION"]
+    action: Ignore
+```
+
 ## Column mapping
 
 Column mapping 提供对表的列值进行修改的功能。可以根据不同的表达式对表的指定列做不同的修改操作，目前只支持 DM 提供的内置表达式。


### PR DESCRIPTION
This PR adds the SQL statements unsupported by the TiDB parser to the binlog event filter section.

Ref: [original text link](https://github.com/pingcap/tidb-tools/blob/docs/docs/dm/zh_CN/features/binlog-filter.md#%E8%BF%87%E6%BB%A4-TiDB-parser-%E4%B8%8D%E6%94%AF%E6%8C%81%E7%9A%84-SQL-%E8%AF%AD%E5%8F%A5)

@GregoryIan @csuzhangxc @amyangfei PTAL