### PR TITLE
op-guide: remove tab space, update indentation and code fences

### DIFF
--- a/op-guide/upgrade-FAQ.md
+++ b/op-guide/upgrade-FAQ.md
@@ -21,7 +21,7 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 升级前：v2.1.0 及之前版本
 
-    ```SQL
+    ```sql
     tidb > create table t(a varchar(10)) charset=utf8;
     Query OK, 0 rows affected
     Time: 0.106s
@@ -39,14 +39,14 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 升级后：v2.1.1、v2.1.2 会出现下面的问题，v2.1.3 以及之后版本不会出现下面的问题。
 
-    ```SQL
+    ```sql
     tidb > alter table t change column a a varchar(20);
     ERROR 1105 (HY000): unsupported modify column charset utf8mb4 not match origin utf8
     ```
 
 解决方案：显式指定 column charset，保持和原来的 charset 一致即可。
 
-    ```SQL
+    ```sql
     alter table t change column a a varchar(22) character set utf8;
     ```
 
@@ -54,14 +54,14 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 根据要点 2，用 HTTP API 获取 table 元信息，然后根据 column 名字和 Charset 关键字搜索即可找到 column 的 charset。
 
-    ```shell
+    ```sh
     ▶ curl "http://$IP:10080/schema/test/t" | python -m json.tool  # 这里用了 python 的格式化 json的工具，也可以不加，此处只是为了方便注释。
     {
         "ShardRowIDBits": 0,
         "auto_inc_id": 0,
         "charset": "utf8",   # 这是 table 的 charset
         "collate": "",
-        "cols": [			 # 从这里开始列举 column 的相关信息
+        "cols": [            # 从这里开始列举 column 的相关信息
             {
                 ...
                 "id": 1,
@@ -91,7 +91,7 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 升级前：v2.1.1，v2.1.2
 
-    ```SQL
+    ```sql
     tidb > create table t(a varchar(10)) charset=utf8;
     Query OK, 0 rows affected
     Time: 0.109s
@@ -109,7 +109,7 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 升级后：v2.1.3 及之后版本
 
-    ```SQL
+    ```sql
     tidb > show create table t
     +-------+--------------------------------------------------------------------+
     | Table | Create Table                                                       |
@@ -126,13 +126,13 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 因为在 v2.1.3 之后，TiDB 支持修改 column 和 table 的 charset，所以这里推荐修改 table 的 charset 为 UTF8MB4。
 
-    ```SQL
+    ```sql
     alter table t convert to character set utf8mb4;
     ```
 
 也可以像问题 1 一样指定 column 的 charset，保持和 column 原来的 charset (UTF8MB4) 一致即可。
 
-    ```SQL
+    ```sql
     alter table t change column a a varchar(20) character set utf8mb4;
     ```
 
@@ -142,7 +142,7 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 
 升级前：v2.1.1 及之前版本
 
-    ```SQL
+    ```sql
     tidb> create table t(a varchar(100) charset utf8);
     Query OK, 0 rows affected
     tidb> insert t values (unhex('f09f8c80'));
@@ -151,7 +151,7 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 
 升级后：v2.1.2 及之后版本
 
-    ```SQL
+    ```sql
     tidb> insert t values (unhex('f09f8c80'));
     ERROR 1366 (HY000): incorrect utf8 value f09f8c80(🌀) for column a
     ```
@@ -160,7 +160,7 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 
 - v2.1.2 版本：该版本不支持修改 column charset，所以只能跳过 UTF8 的检查。
 
-    ```SQL
+    ```sql
     tidb > set @@session.tidb_skip_utf8_check=1;
     Query OK, 0 rows affected
     tidb > insert t values (unhex('f09f8c80'));
@@ -169,7 +169,7 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 
 - v2.1.3 及之后版本：建议修改 column 的 charset 为 UTF8MB4。或者也可以设置 `tidb_skip_utf8_check` 变量跳过 UTF8 的检查。如果跳过 UTF8 的检查，在需要将数据从 TiDB 同步回 MySQL 的时候，可能会失败，因为 MySQL 会执行该检查。
 
-    ```SQL
+    ```sql
     tidb > alter table t change column a a varchar(100) character set utf8mb4;
     Query OK, 0 rows affected
     tidb > insert t values (unhex('f09f8c80'));
@@ -183,15 +183,18 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 `tidb_check_mb4_value_in_utf8` 在 v2.1.5 版本开始可以用 HTTP API 来设置，也可以用 session 变量来设置。
 
 * HTTP API（HTTP API 只在单台服务器上生效）
-    ```shell
+
+    ```sh
     # Enabled
     curl -X POST -d "check_mb4_value_in_utf8=1" http://{TiDBIP}:10080/settings
 
     # Disable
     curl -X POST -d "check_mb4_value_in_utf8=0" http://{TiDBIP}:10080/settings
     ```
+
 * Session 变量
-    ```SQL
+
+    ```sql
     # Enabled
     set @@session.tidb_check_mb4_value_in_utf8 = 1;
 

--- a/op-guide/upgrade-FAQ.md
+++ b/op-guide/upgrade-FAQ.md
@@ -21,120 +21,120 @@ TiDB 在 v2.1.0 以及之前版本（包括 v2.0 所有版本）中，默认字�
 
 升级前：v2.1.0 及之前版本
 
-    ```sql
-    tidb > create table t(a varchar(10)) charset=utf8;
-    Query OK, 0 rows affected
-    Time: 0.106s
-    tidb > show create table t
-    +-------+-------------------------------------------------------+
-    | Table | Create Table                                          |
-    +-------+-------------------------------------------------------+
-    | t     | CREATE TABLE `t` (                                    |
-    |       |   `a` varchar(10) DEFAULT NULL                        |
-    |       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
-    +-------+-------------------------------------------------------+
-    1 row in set
-    Time: 0.006s
-    ```
+```sql
+tidb > create table t(a varchar(10)) charset=utf8;
+Query OK, 0 rows affected
+Time: 0.106s
+tidb > show create table t
++-------+-------------------------------------------------------+
+| Table | Create Table                                          |
++-------+-------------------------------------------------------+
+| t     | CREATE TABLE `t` (                                    |
+|       |   `a` varchar(10) DEFAULT NULL                        |
+|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
++-------+-------------------------------------------------------+
+1 row in set
+Time: 0.006s
+```
 
 升级后：v2.1.1、v2.1.2 会出现下面的问题，v2.1.3 以及之后版本不会出现下面的问题。
 
-    ```sql
-    tidb > alter table t change column a a varchar(20);
-    ERROR 1105 (HY000): unsupported modify column charset utf8mb4 not match origin utf8
-    ```
+```sql
+tidb > alter table t change column a a varchar(20);
+ERROR 1105 (HY000): unsupported modify column charset utf8mb4 not match origin utf8
+```
 
 解决方案：显式指定 column charset，保持和原来的 charset 一致即可。
 
-    ```sql
-    alter table t change column a a varchar(22) character set utf8;
-    ```
+```sql
+alter table t change column a a varchar(22) character set utf8;
+```
 
 根据要点 1，此处如果不指定 column 的 charset，会用默认的 UTF8MB4，所以需要指定 column charset 保持和原来一致。
 
 根据要点 2，用 HTTP API 获取 table 元信息，然后根据 column 名字和 Charset 关键字搜索即可找到 column 的 charset。
 
-    ```sh
-    ▶ curl "http://$IP:10080/schema/test/t" | python -m json.tool  # 这里用了 python 的格式化 json的工具，也可以不加，此处只是为了方便注释。
-    {
-        "ShardRowIDBits": 0,
-        "auto_inc_id": 0,
-        "charset": "utf8",   # 这是 table 的 charset
-        "collate": "",
-        "cols": [            # 从这里开始列举 column 的相关信息
-            {
-                ...
-                "id": 1,
-                "name": {
-                    "L": "a",
-                    "O": "a"   # column 的名字
-                },
-                "offset": 0,
-                "origin_default": null,
-                "state": 5,
-                "type": {
-                    "Charset": "utf8",   # column a 的 charset
-                    "Collate": "utf8_bin",
-                    "Decimal": 0,
-                    "Elems": null,
-                    "Flag": 0,
-                    "Flen": 10,
-                    "Tp": 15
-                }
+```sh
+▶ curl "http://$IP:10080/schema/test/t" | python -m json.tool  # 这里用了 python 的格式化 json的工具，也可以不加，此处只是为了方便注释。
+{
+    "ShardRowIDBits": 0,
+    "auto_inc_id": 0,
+    "charset": "utf8",   # 这是 table 的 charset
+    "collate": "",
+    "cols": [            # 从这里开始列举 column 的相关信息
+        {
+            ...
+            "id": 1,
+            "name": {
+                "L": "a",
+                "O": "a"   # column 的名字
+            },
+            "offset": 0,
+            "origin_default": null,
+            "state": 5,
+            "type": {
+                "Charset": "utf8",   # column a 的 charset
+                "Collate": "utf8_bin",
+                "Decimal": 0,
+                "Elems": null,
+                "Flag": 0,
+                "Flen": 10,
+                "Tp": 15
             }
-        ],
-        ...
-    }
-    ```
+        }
+    ],
+    ...
+}
+```
 
 ### 问题 2：`unsupported modify charset from utf8mb4 to utf8`
 
 升级前：v2.1.1，v2.1.2
 
-    ```sql
-    tidb > create table t(a varchar(10)) charset=utf8;
-    Query OK, 0 rows affected
-    Time: 0.109s
-    tidb > show create table t
-    +-------+-------------------------------------------------------+
-    | Table | Create Table                                          |
-    +-------+-------------------------------------------------------+
-    | t     | CREATE TABLE `t` (                                    |
-    |       |   `a` varchar(10) DEFAULT NULL                        |
-    |       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
-    +-------+-------------------------------------------------------+
-    ```
+```sql
+tidb > create table t(a varchar(10)) charset=utf8;
+Query OK, 0 rows affected
+Time: 0.109s
+tidb > show create table t
++-------+-------------------------------------------------------+
+| Table | Create Table                                          |
++-------+-------------------------------------------------------+
+| t     | CREATE TABLE `t` (                                    |
+|       |   `a` varchar(10) DEFAULT NULL                        |
+|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin |
++-------+-------------------------------------------------------+
+```
 
 上面 `show create table` 只显示出了 table 的 charset，但其实 column 的 charset 是 UTF8MB4，这可以通过 HTTP API 获取 schema 来确认。这是一个 bug，即此处建表时 column 的 charset 应该要和 table 保持一致为 UTF8，该问题在 v2.1.3 中已经修复。
 
 升级后：v2.1.3 及之后版本
 
-    ```sql
-    tidb > show create table t
-    +-------+--------------------------------------------------------------------+
-    | Table | Create Table                                                       |
-    +-------+--------------------------------------------------------------------+
-    | t     | CREATE TABLE `t` (                                                 |
-    |       |   `a` varchar(10) CHARSET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL |
-    |       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin              |
-    +-------+--------------------------------------------------------------------+
-    1 row in set
-    Time: 0.007s
-    tidb > alter table t change column a a varchar(20);
-    ERROR 1105 (HY000): unsupported modify charset from utf8mb4 to utf8
-    ```
+```sql
+tidb > show create table t
++-------+--------------------------------------------------------------------+
+| Table | Create Table                                                       |
++-------+--------------------------------------------------------------------+
+| t     | CREATE TABLE `t` (                                                 |
+|       |   `a` varchar(10) CHARSET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL |
+|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin              |
++-------+--------------------------------------------------------------------+
+1 row in set
+Time: 0.007s
+tidb > alter table t change column a a varchar(20);
+ERROR 1105 (HY000): unsupported modify charset from utf8mb4 to utf8
+```
 
 因为在 v2.1.3 之后，TiDB 支持修改 column 和 table 的 charset，所以这里推荐修改 table 的 charset 为 UTF8MB4。
 
-    ```sql
-    alter table t convert to character set utf8mb4;
-    ```
+```sql
+alter table t convert to character set utf8mb4;
+```
 
 也可以像问题 1 一样指定 column 的 charset，保持和 column 原来的 charset (UTF8MB4) 一致即可。
 
-    ```sql
-    alter table t change column a a varchar(20) character set utf8mb4;
-    ```
+```sql
+alter table t change column a a varchar(20) character set utf8mb4;
+```
 
 ### 问题 3：`ERROR 1366 (HY000): incorrect utf8 value f09f8c80(🌀) for column a`
 
@@ -142,19 +142,19 @@ TiDB 在 v2.1.1 及之前版本中，如果 charset 是 UTF8，没有对 4-byte 
 
 升级前：v2.1.1 及之前版本
 
-    ```sql
-    tidb> create table t(a varchar(100) charset utf8);
-    Query OK, 0 rows affected
-    tidb> insert t values (unhex('f09f8c80'));
-    Query OK, 1 row affected
-    ```
+```sql
+tidb> create table t(a varchar(100) charset utf8);
+Query OK, 0 rows affected
+tidb> insert t values (unhex('f09f8c80'));
+Query OK, 1 row affected
+```
 
 升级后：v2.1.2 及之后版本
 
-    ```sql
-    tidb> insert t values (unhex('f09f8c80'));
-    ERROR 1366 (HY000): incorrect utf8 value f09f8c80(🌀) for column a
-    ```
+```sql
+tidb> insert t values (unhex('f09f8c80'));
+ERROR 1366 (HY000): incorrect utf8 value f09f8c80(🌀) for column a
+```
 
 解决方案：
 


### PR DESCRIPTION
- The incorrect indentation causes display errors at the PingCAP website. 
- The Tab spaces cause the CI failure.
- Keep the code fences in lowercase.

This PR fixes them. @CaitinChen @crazycs520 PTAL

@CaitinChen Please pay attention to the above issues in https://github.com/pingcap/docs/pull/947 when you help review it. Thanks!

