### PR TITLE
tools: update the loader pprof-addr default port

### DIFF
--- a/tools/loader.md
+++ b/tools/loader.md
@@ -57,7 +57,7 @@ Loader 包含在 tidb-enterprise-tools 安装包中，可[在此下载](../tools
   -p string
       TiDB 账户密码
   -pprof-addr string
-      Loader 的 pprof 地址，用于对 Loader 进行性能调试 (默认为 ":10084")
+      Loader 的 pprof 地址，用于对 Loader 进行性能调试 (默认为 ":8272")
   -t int
       线程数 (默认为 16). 每个线程同一时刻只能操作一个数据文件。
   -u string
@@ -78,8 +78,8 @@ log-file = "loader.log"
 # 需要导入的数据存放路径 (default "./")
 dir = "./"
 
-#  Loader 的 pprof 地址，用于对 Loader 进行性能调试 (默认为 ":10084")
-pprof-addr = "127.0.0.1:10084"
+#  Loader 的 pprof 地址，用于对 Loader 进行性能调试 (默认为 ":8272")
+pprof-addr = ":8272"
 
 # checkpoint 数据库名，loader 在运行过程中会不断的更新这个数据库，在中断并恢复后，
 # 会通过这个库获取上次运行的进度 (默认为 "tidb_loader")


### PR DESCRIPTION
This PR update the pprof-addr default port in Loader documents.

According to the https://internal.pingcap.net/confluence/pages/viewpage.action?pageId=21273346, Loader pprof-addr default port has changed from 10084 to 8272 while the public documents is out of date. 

Loader code for reference: 
https://github.com/pingcap/tidb-enterprise-tools/blob/master/loader/config.go
fs.StringVar(&cfg.PprofAddr, "pprof-addr", ":8272", "Loader pprof addr")