### PR TITLE
tools: change the link of back-restore in tidb-binlog document

### DIFF
--- a/tools/tidb-binlog-cluster.md
+++ b/tools/tidb-binlog-cluster.md
@@ -198,7 +198,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 2. 全量数据的备份与恢复
 
-    推荐使用 mydumper 备份 TiDB 的全量数据，再使用 loader 将备份数据导入到下游。具体使用方法参考：[备份与恢复](https://github.com/pingcap/docs-cn/blob/master/op-guide/backup-restore.md)。
+    推荐使用 mydumper 备份 TiDB 的全量数据，再使用 loader 将备份数据导入到下游。具体使用方法参考：[备份与恢复](../op-guide/backup-restore.md)。
 
 3. 修改 `tidb-ansible/inventory.ini` 文件
 


### PR DESCRIPTION
TiDB-binlog backup-restore uses a link to https://github.com/pingcap/docs-cn/blob/master/op-guide/backup-restore.md while link to the local markdown file.

This lead to a problem that when you click the back-store on the document website of tidb-binlog, it will route you to the github rathar than to the document website of backup-store.

This PR aims to fix this problem. Pls take a review. 