### PR TITLE
sql: update the USE command explanation in util document

### DIFF
--- a/sql/util.md
+++ b/sql/util.md
@@ -93,7 +93,7 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database，即默认使用当前选定的 Database。
 
 ## `TRACE` 语句
 

--- a/sql/util.md
+++ b/sql/util.md
@@ -93,8 +93,7 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-
-切换默认 Database，当 SQL 语句中的表没有显式指定的 Database 时，即使用默认 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。
 
 ## `TRACE` 语句
 

--- a/v1.0/sql/util.md
+++ b/v1.0/sql/util.md
@@ -91,4 +91,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database，即默认使用当前选定的 Database。

--- a/v1.0/sql/util.md
+++ b/v1.0/sql/util.md
@@ -91,4 +91,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换默认 Database，当 SQL 语句中的表没有显式指定的 Database 时，即使用默认 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。

--- a/v2.0/sql/util.md
+++ b/v2.0/sql/util.md
@@ -91,4 +91,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database，即默认使用当前选定的 Database。

--- a/v2.0/sql/util.md
+++ b/v2.0/sql/util.md
@@ -91,4 +91,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换默认 Database，当 SQL 语句中的表没有显式指定的 Database 时，即使用默认 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。

--- a/v2.1/sql/util.md
+++ b/v2.1/sql/util.md
@@ -93,4 +93,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换默认 Database，当 SQL 语句中的表没有显式指定的 Database 时，即使用默认 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。

--- a/v2.1/sql/util.md
+++ b/v2.1/sql/util.md
@@ -93,4 +93,4 @@ dot xx.dot -T png -O
 USE db_name
 ```
 
-切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。
+切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database，即默认使用当前选定的 Database。


### PR DESCRIPTION
### PR background
User provided feedback that our explanation of TiDB 'USE' command in util document is not quite accurate: the meaning of default database is confusing.
Detailed at the issue link: https://github.com/pingcap/docs-cn/issues/1112

### What has done in the PR
I updated the  explanation of TiDB 'USE' command in sql/util.md documents (1.0/2.0/2.1).
Previously: '切换默认 Database，当 SQL 语句中的表没有显式指定的 Database 时，即使用默认 Database。'
Updated: '切换需要使用的 Database 的时候，如果 SQL 语句中的表没有显式指定的 Database ，即默认使用当前选定的 Database。'