### PR TITLE
*: rename how-to deploy files

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -15,15 +15,15 @@
     - [SQL 基本操作](dev/how-to/get-started/explore-sql.md)
     - [读取历史数据](dev/how-to/get-started/read-historical-data.md)
   - 部署
-    - [软硬件环境需求](op-guide/recommendation.md)
+    - [软硬件环境需求](dev/how-to/deploy/hardware-recommendations.md)
     + 集群部署方式
-      - [使用 Ansible 部署（推荐）](op-guide/ansible-deployment.md)
-      - [使用 Ansible 离线部署](op-guide/offline-ansible-deployment.md)
-      - [使用 Docker 部署](op-guide/docker-deployment.md)
+      - [使用 Ansible 部署（推荐）](dev/how-to/deploy/orchestrated/ansible.md)
+      - [使用 Ansible 离线部署](dev/how-to/deploy/orchestrated/offline-ansible.md)
+      - [使用 Docker 部署](dev/how-to/deploy/orchestrated/docker.md)
     + 跨地域冗余
-      - [跨数据中心部署方案](op-guide/cross-dc-deployment.md)
-      - [配置集群拓扑](op-guide/location-awareness.md)
-    - [TiSpark 快速上手](tispark/tispark-quick-start-guide.md)
+      - [跨数据中心部署方案](dev/how-to/deploy/geographic-redundancy/overview.md)
+      - [配置集群拓扑](dev/how-to/deploy/geographic-redundancy/location-awareness.md)
+    - [TiSpark 快速上手](dev/how-to/deploy/tispark.md)
     - [使用 Ansible 部署 DM 集群](tools/dm/deployment.md)
   + 安全
     - [与 MySQL 的安全特性差异](sql/security-compatibility.md)

--- a/dev/how-to/deploy/geographic-redundancy/location-awareness.md
+++ b/dev/how-to/deploy/geographic-redundancy/location-awareness.md
@@ -1,6 +1,7 @@
 ---
 title: 集群拓扑信息配置
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/location-awareness/']
 ---
 
 # 集群拓扑信息配置
@@ -9,7 +10,7 @@ category: deployment
 
 PD 能够根据 TiKV 集群的拓扑结构进行调度，使得 TiKV 的容灾能力最大化。
 
-阅读本章前，请先确保阅读 [Ansible 部署方案](../op-guide/ansible-deployment.md) 和 [Docker 部署方案](../op-guide/docker-deployment.md)。
+阅读本章前，请先确保阅读 [Ansible 部署方案](/dev/how-to/deploy/orchestrated/ansible.md) 和 [Docker 部署方案](/dev/how-to/deploy/orchestrated/docker.md)。
 
 ## TiKV 上报拓扑信息
 

--- a/dev/how-to/deploy/geographic-redundancy/overview.md
+++ b/dev/how-to/deploy/geographic-redundancy/overview.md
@@ -1,6 +1,7 @@
 ---
 title: 跨数据中心部署方案
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/cross-dc-deployment/']
 ---
 
 # 跨数据中心部署方案
@@ -11,13 +12,13 @@ category: deployment
 
 TiDB, TiKV, PD 分别分布在 3 个不同的中心，这是最常规，可用性最高的方案。
 
-![三中心部署](../media/deploy-3dc.png)
+![三中心部署](/media/deploy-3dc.png)
 
 ### 优点
 
 所有数据的副本分布在三个数据中心，任何一个数据中心失效后，另外两个数据中心会自动发起 leader election，并在合理长的时间内（通常情况 20s 以内）恢复服务，并且不会产生数据丢失。
 
-![三中心部署容灾](../media/deploy-3dc-dr.png)
+![三中心部署容灾](/media/deploy-3dc-dr.png)
 
 ### 缺点
 
@@ -31,13 +32,13 @@ TiDB, TiKV, PD 分别分布在 3 个不同的中心，这是最常规，可用�
 
 如果不需要每个数据中心同时对外提供服务，可以将业务流量全部派发到一个数据中心，并通过调度策略把 Region leader 和 PD leader 都迁移到同一个数据中心（我们在上文所述的测试中也做了这个优化）。这样一来，不管是从 PD 获取 TSO 还是读取 Region 都不受数据中心间网络的影响。当该数据中心失效后，PD leader 和 Region leader 会自动在其它数据中心选出，只需要把业务流量转移至其他存活的数据中心即可。
 
-![三中心部署读性能优化](../media/deploy-3dc-optimize.png)
+![三中心部署读性能优化](/media/deploy-3dc-optimize.png)
 
 ## 两地三中心部署方案
 
 两地三中心的方案与三数据中心类似，算是三机房方案根据业务特点进行的优化，区别是其中有两个数据中心距离很近（通常在同一个城市），网络延迟相对很小。这种场景下，我们可以把业务流量同时派发到同城的两个数据中心，同时控制 Region leader 和 PD leader 也分布在同城的两个数据中心。
 
-![两地三中心部署方案](../media/deploy-2city3dc.png)
+![两地三中心部署方案](/media/deploy-2city3dc.png)
 
 与三数据中心方案相比，两地三中心有以下优势：
 
@@ -51,11 +52,11 @@ TiDB, TiKV, PD 分别分布在 3 个不同的中心，这是最常规，可用�
 
 两数据中心 + binlog 同步类似于传统的 MySQL 中 master/slave 方案。两个数据中心分别部署一套完整的 TiDB 集群，我们称之为主集群和从集群。正常情况下所有的请求都在主集群，写入的数据通过 binlog 异步同步至从集群并写入。
 
-![binlog 同步部署方案](../media/deploy-binlog.png)
+![binlog 同步部署方案](/media/deploy-binlog.png)
 
 当主集群整个数据中心失效后，业务可以切换至从集群，与 MySQL 类似，这种情况下会有一些数据缺失。对比 MySQL，这个方案的优势是数据中心内的 HA -- 少部分节点故障时，通过重新选举 leader 自动恢复服务，不需要人工干预。
 
-![两中心 binlog 相互备份方案](../media/deploy-backup.png)
+![两中心 binlog 相互备份方案](/media/deploy-backup.png)
 
 另外部分用户采用这种方式做双数据中心多活，两个数据中心各有一个集群，将业务分为两个库，每个库服务一部分数据，每个数据中心的业务只会访问一个库，两个集群之间通过 binlog 将本数据中心业务所涉及的库中的数据变更同步到对端机房，形成环状备份。
 

--- a/dev/how-to/deploy/hardware-recommendations.md
+++ b/dev/how-to/deploy/hardware-recommendations.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB 软件和硬件环境建议配置
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/recommendation/']
 ---
 
 # TiDB 软件和硬件环境建议配置

--- a/dev/how-to/deploy/orchestrated/ansible.md
+++ b/dev/how-to/deploy/orchestrated/ansible.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB-Ansible 部署方案
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/ansible-deployment/']
 ---
 
 # TiDB-Ansible 部署方案
@@ -13,30 +14,30 @@ Ansible 是一款自动化运维工具，[TiDB-Ansible](https://github.com/pingc
 
 - 初始化操作系统参数
 - 部署 TiDB 集群（包括 PD、TiDB、TiKV 等组件和监控组件）
-- [启动集群](../op-guide/ansible-operation.md#启动集群)
-- [关闭集群](../op-guide/ansible-operation.md#关闭集群)
-- [变更组件配置](../op-guide/ansible-deployment-rolling-update.md#变更组件配置)
-- [集群扩容缩容](../op-guide/ansible-deployment-scale.md)
-- [升级组件版本](../op-guide/ansible-deployment-rolling-update.md#升级组件版本)
-- [集群开启 binlog](../tools/tidb-binlog-cluster.md)
-- [清除集群数据](../op-guide/ansible-operation.md#清除集群数据)
-- [销毁集群](../op-guide/ansible-operation.md#销毁集群)
+- [启动集群](/op-guide/ansible-operation.md#启动集群)
+- [关闭集群](/op-guide/ansible-operation.md#关闭集群)
+- [变更组件配置](/op-guide/ansible-deployment-rolling-update.md#变更组件配置)
+- [集群扩容缩容](/op-guide/ansible-deployment-scale.md)
+- [升级组件版本](/op-guide/ansible-deployment-rolling-update.md#升级组件版本)
+- [集群开启 binlog](/tools/tidb-binlog-cluster.md)
+- [清除集群数据](/op-guide/ansible-operation.md#清除集群数据)
+- [销毁集群](/op-guide/ansible-operation.md#销毁集群)
 
 > **注意：**
 >
-> 对于生产环境，须使用 TiDB-Ansible 部署 TiDB 集群。如果只是用于测试 TiDB 或体验 TiDB 的特性，建议[使用 Docker Compose 在单机上快速部署 TiDB 集群](../op-guide/docker-compose.md)。
+> 对于生产环境，须使用 TiDB-Ansible 部署 TiDB 集群。如果只是用于测试 TiDB 或体验 TiDB 的特性，建议[使用 Docker Compose 在单机上快速部署 TiDB 集群](/dev/how-to/get-started/local-cluster/install-from-docker-compose.md)。
 
 ## 准备机器
 
 1.  部署目标机器若干
 
-    - 建议 4 台及以上，TiKV 至少 3 实例，且与 TiDB、PD 模块不位于同一主机，详见[部署建议](../op-guide/recommendation.md)。
+    - 建议 4 台及以上，TiKV 至少 3 实例，且与 TiDB、PD 模块不位于同一主机，详见[部署建议](/dev/how-to/deploy/hardware-recommendations.md)。
     - 推荐安装 CentOS 7.3 及以上版本 Linux 操作系统，x86_64 架构 (amd64)。
     - 机器之间内网互通。
 
     > **注意：**
     >
-    > 使用 Ansible 方式部署时，TiKV 及 PD 节点数据目录所在磁盘请使用 SSD 磁盘，否则无法通过检测。** 如果仅验证功能，建议使用 [Docker Compose 部署方案](../op-guide/docker-compose.md)单机进行测试。
+    > 使用 Ansible 方式部署时，TiKV 及 PD 节点数据目录所在磁盘请使用 SSD 磁盘，否则无法通过检测。** 如果仅验证功能，建议使用 [Docker Compose 部署方案](/dev/how-to/get-started/local-cluster/install-from-docker-compose.md)单机进行测试。
 
 2.  部署中控机一台:
 
@@ -326,7 +327,7 @@ UUID=c51eb23b-195c-4061-92a9-3fad812cc12f /data1 ext4 defaults,nodelalloc,noatim
 - 3 个 PD 节点
 - 3 个 TiKV 节点，第一台 TiDB 机器同时用作监控机
 
-默认情况下，单台机器上只需部署一个 TiKV 实例。如果你的 TiKV 部署机器 CPU 及内存配置是[部署建议](../op-guide/recommendation.md)的两倍或以上，并且拥有两块 SSD 硬盘或单块容量超 2T 的 SSD 硬盘，可以考虑部署两实例，但不建议部署两个以上实例。
+默认情况下，单台机器上只需部署一个 TiKV 实例。如果你的 TiKV 部署机器 CPU 及内存配置是[部署建议](/dev/how-to/deploy/hardware-recommendations.md)的两倍或以上，并且拥有两块 SSD 硬盘或单块容量超 2T 的 SSD 硬盘，可以考虑部署两实例，但不建议部署两个以上实例。
 
 ### 单机单 TiKV 实例集群拓扑
 
@@ -480,8 +481,8 @@ TiKV1-1 ansible_host=172.16.10.4 deploy_dir=/data1/deploy
 | cluster_name | 集群名称，可调整 |
 | tidb_version | TiDB 版本，TiDB-Ansible 各分支默认已配置 |
 | process_supervision | 进程监管方式，默认为 systemd，可选 supervise |
-| timezone | 新安装 TiDB 集群第一次启动 bootstrap（初始化）时，将 TiDB 全局默认时区设置为该值。TiDB 使用的时区后续可通过 `time_zone` 全局变量和 session 变量来修改，参考[时区支持](../sql/time-zone.md)。 默认为 `Asia/Shanghai`，可选值参考[ timzone 列表](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)。 |
-| enable_firewalld | 开启防火墙，默认不开启，如需开启，请将[部署建议-网络要求](recommendation.md#网络要求) 中的端口加入白名单 |
+| timezone | 新安装 TiDB 集群第一次启动 bootstrap（初始化）时，将 TiDB 全局默认时区设置为该值。TiDB 使用的时区后续可通过 `time_zone` 全局变量和 session 变量来修改，参考[时区支持](/sql/time-zone.md)。 默认为 `Asia/Shanghai`，可选值参考 [timzone 列表](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)。 |
+| enable_firewalld | 开启防火墙，默认不开启，如需开启，请将[部署建议-网络要求](/dev/how-to/deploy/hardware-recommendations.md#网络要求) 中的端口加入白名单 |
 | enable_ntpd | 检测部署目标机器 NTP 服务，默认为 True，请勿关闭 |
 | set_hostname | 根据 IP 修改部署目标机器主机名，默认为 False |
 | enable_binlog | 是否部署 pump 并开启 binlog，默认为 False，依赖 Kafka 集群，参见 `zookeeper_addrs` 变量 |

--- a/dev/how-to/deploy/orchestrated/docker.md
+++ b/dev/how-to/deploy/orchestrated/docker.md
@@ -1,6 +1,7 @@
 ---
 title: TiDB Docker 部署方案
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/docker-deployment/']
 ---
 
 # TiDB Docker 部署方案
@@ -9,7 +10,7 @@ category: deployment
 
 > **注意：**
 >
-> 对于生产环境，不要使用 Docker 进行部署，而应[使用 Ansible 部署 TiDB 集群](../op-guide/ansible-deployment.md)。
+> 对于生产环境，不要使用 Docker 进行部署，而应[使用 Ansible 部署 TiDB 集群](/dev/how-to/deploy/orchestrated/ansible.md)。
 
 ## 环境准备
 

--- a/dev/how-to/deploy/orchestrated/offline-ansible.md
+++ b/dev/how-to/deploy/orchestrated/offline-ansible.md
@@ -1,6 +1,7 @@
 ---
 title: 离线 TiDB-Ansible 部署方案
-category: deployment
+category: how-to
+aliases: ['/docs-cn/op-guide/offline-ansible-deployment/']
 ---
 
 # 离线 TiDB-Ansible 部署方案
@@ -14,7 +15,7 @@ category: deployment
 
 2. 部署目标机器若干及部署中控机一台
 
-    - 系统要求及配置参考[准备机器](../op-guide/ansible-deployment.md#准备机器)。
+    - 系统要求及配置参考[准备机器](/dev/how-to/deploy/orchestrated/ansible.md#准备机器)。
     - 可以无法访问外网。
 
 ## 在中控机上安装系统依赖包
@@ -39,7 +40,7 @@ category: deployment
 
 ## 在中控机上创建 tidb 用户，并生成 ssh key
 
-参考[在中控机上创建 tidb 用户，并生成 ssh key](../op-guide/ansible-deployment.md#在中控机上创建-tidb-用户-并生成-ssh-key) 即可。
+参考[在中控机上创建 tidb 用户，并生成 ssh key](/dev/how-to/deploy/orchestrated/ansible.md#在中控机上创建-tidb-用户-并生成-ssh-key) 即可。
 
 ## 在中控机器上离线安装 Ansible 及其依赖
 
@@ -118,25 +119,25 @@ category: deployment
 
 ## 在中控机上配置部署机器 ssh 互信及 sudo 规则
 
-参考[在中控机上配置部署机器 ssh 互信及 sudo 规则](../op-guide/ansible-deployment.md#在中控机上配置部署机器-ssh-互信及-sudo-规则)即可。
+参考[在中控机上配置部署机器 ssh 互信及 sudo 规则](/dev/how-to/deploy/orchestrated/ansible.md#在中控机上配置部署机器-ssh-互信及-sudo-规则)即可。
 
 ## 在部署目标机器上安装 NTP 服务
 
-> 如果你的部署目标机器时间、时区设置一致，已开启 NTP 服务且在正常同步时间，此步骤可忽略，可参考[如何检测 NTP 服务是否正常](../op-guide/ansible-deployment.md#如何检测-ntp-服务是否正常)。
+> 如果你的部署目标机器时间、时区设置一致，已开启 NTP 服务且在正常同步时间，此步骤可忽略，可参考[如何检测 NTP 服务是否正常](/dev/how-to/deploy/orchestrated/ansible.md#如何检测-ntp-服务是否正常)。
 
-参考[在部署目标机器上安装 NTP 服务](../op-guide/ansible-deployment.md#在部署目标机器上安装-ntp-服务)即可。
+参考[在部署目标机器上安装 NTP 服务](/dev/how-to/deploy/orchestrated/ansible.md#在部署目标机器上安装-ntp-服务)即可。
 
 ## 在部署目标机器上配置 CPUfreq 调节器模式
 
-参考[在部署目标机器上配置 CPUfreq 调节器模式](../op-guide/ansible-deployment.md#在部署目标机器上配置-cpufreq-调节器模式)即可。
+参考[在部署目标机器上配置 CPUfreq 调节器模式](/dev/how-to/deploy/orchestrated/ansible.md#在部署目标机器上配置-cpufreq-调节器模式)即可。
 
 ## 在部署目标机器上添加数据盘 ext4 文件系统挂载参数
 
-参考[在部署目标机器上添加数据盘 ext4 文件系统挂载参数](../op-guide/ansible-deployment.md#在部署目标机器上添加数据盘-ext4-文件系统挂载参数)即可。
+参考[在部署目标机器上添加数据盘 ext4 文件系统挂载参数](/dev/how-to/deploy/orchestrated/ansible.md#在部署目标机器上添加数据盘-ext4-文件系统挂载参数)即可。
 
 ## 分配机器资源，编辑 inventory.ini 文件
 
-参考[分配机器资源，编辑 inventory.ini 文件](../op-guide/ansible-deployment.md#分配机器资源-编辑-inventory-ini-文件)即可。
+参考[分配机器资源，编辑 inventory.ini 文件](/dev/how-to/deploy/orchestrated/ansible.md#分配机器资源-编辑-inventory-ini-文件)即可。
 
 ## 部署任务
 
@@ -151,8 +152,8 @@ category: deployment
     $ ./install_grafana_font_rpms.sh
     ```
 
-3.  参考[部署任务](../op-guide/ansible-deployment.md#部署任务)即可。
+3.  参考[部署任务](/dev/how-to/deploy/orchestrated/ansible.md#部署任务)即可。
 
 ## 测试集群
 
-参考[测试集群](../op-guide/ansible-deployment.md#测试集群)即可。
+参考[测试集群](/dev/how-to/deploy/orchestrated/ansible.md#测试集群)即可。

--- a/dev/how-to/deploy/tispark.md
+++ b/dev/how-to/deploy/tispark.md
@@ -1,11 +1,12 @@
 ---
 title: TiSpark 快速入门指南
-category: tispark
+category: how-to
+aliases: ['/docs-cn/tispark/tispark-quick-start-guide/']
 ---
 
 # TiSpark 快速入门指南
 
-为了让大家快速体验 [TiSpark](../tispark/tispark-user-guide.md)，通过 TiDB-Ansible 安装的 TiDB 集群中默认已集成 Spark、TiSpark jar 包及 TiSpark sample data。
+为了让大家快速体验 [TiSpark](/tispark/tispark-user-guide.md)，通过 TiDB-Ansible 安装的 TiDB 集群中默认已集成 Spark、TiSpark jar 包及 TiSpark sample data。
 
 ## 部署信息
 


### PR DESCRIPTION
This PR renames all How-to Deploy files except "使用 Ansible 部署 DM 集群", because this file was not actually renamed in the corresponding docs PR (https://github.com/pingcap/docs/pull/1048), and I wonder whether it's more appropriate to keep it in "tools/dm". It's weird to move only this file out.

@dcalvin @YiniXu9506 PTAL

Related PR: https://github.com/pingcap/docs/pull/1048