### PR TITLE
tools/dm: fix the error in valus from ansible command

### DIFF
--- a/tools/dm/deployment.md
+++ b/tools/dm/deployment.md
@@ -402,7 +402,7 @@ dm-worker2 ansible_host=172.16.10.73 source_id="mysql-replica-02" server_id=102 
    >
    > 请勿将 `ansible_user` 设为 `root`，因为 `tidb-ansible` 限制服务需以普通用户运行。
 
-    运行以下命令。如果所有服务都返回 `root`，则 SSH 互信配置成功。
+    运行以下命令。如果所有服务都返回 `tidb`，则 SSH 互信配置成功。
 
     ```bash
     ansible -i inventory.ini all -m shell -a 'whoami'


### PR DESCRIPTION
### PR background  
When checking the [dm-deployment](https://pingcap.com/docs-cn/tools/dm/deployment/), i found an mistake in the return value of `ansible -i inventory.ini all -m shell -a 'whoami'`. 
In the document Step 9, it mentioned that you will get `root` when running the command of `ansible -i inventory.ini all -m shell -a 'whoami'` while the correct value should be `tidb`.

My testing:

```
tidb@OPS:~/dm-ansible$ ansible -i inventory.ini all -m shell -a 'whoami'
dm-worker1 | SUCCESS | rc=0 >>
tidb

dm_master | SUCCESS | rc=0 >>
tidb

tidb@OPS:~/dm-ansible$ ansible -i inventory.ini all -m shell -a 'whoami' -b
dm-worker1 | SUCCESS | rc=0 >>
root

dm_master | SUCCESS | rc=0 >>
root
```
BTW, i also checked the [dm-deployment](https://pingcap.com/docs/tools/dm/deployment/), it's correct. 
![image](https://user-images.githubusercontent.com/10498732/57176378-ddaa2100-6e89-11e9-82d9-3516d2e1e42c.png)

