### PR TITLE
tools: fix the format error in Syncer

### DIFF
--- a/tools/syncer.md
+++ b/tools/syncer.md
@@ -482,7 +482,7 @@ target-table = "order_2017"
     ```
 6. 检查字符集。
 
-    TiDB 和 MySQL 的字符集的兼容性不同，详见 [TiDB 支持的字符集](/sql/character-set-support.md)
+    TiDB 和 MySQL 的字符集的兼容性不同，详见 [TiDB 支持的字符集](/sql/character-set-support.md)。
 
 
 ## 监控方案

--- a/tools/syncer.md
+++ b/tools/syncer.md
@@ -482,7 +482,7 @@ target-table = "order_2017"
     ```
 6. 检查字符集。
 
-   TiDB 和 MySQL 的字符集的兼容性不同，详见 [TiDB 支持的字符集](/sql/character-set-support.md)
+    TiDB 和 MySQL 的字符集的兼容性不同，详见 [TiDB 支持的字符集](/sql/character-set-support.md)
 
 
 ## 监控方案


### PR DESCRIPTION
https://github.com/pingcap/docs-cn/pull/1300 had an indentation as below: 
![image](https://user-images.githubusercontent.com/10498732/57349652-8bb91200-718d-11e9-80df-bb9ebceae63e.png)

Should be caused by the tag indentation. 

This PR aims to fix it. 