### PR TITLE
Revert "TOC: remove release notes"

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -202,6 +202,7 @@
 - [TiDB 路线图](ROADMAP.md)
 + [版本发布历史](releases/rn.md)
   + v3.0
+    - [3.0.0-rc.2](releases/3.0.0-rc.2.md)
     - [3.0.0-rc.1](releases/3.0.0-rc.1.md)
     - [3.0.0-beta.1](releases/3.0.0-beta.1.md)
     - [3.0.0-beta](releases/3.0beta.md)


### PR DESCRIPTION
Reverts pingcap/docs-cn#1372  which was released earlier than supposed. 