### PR TITLE
releases: remove one note of tidb binlog: 

### DIFF
--- a/releases/3.0.0-rc.2.md
+++ b/releases/3.0.0-rc.2.md
@@ -113,7 +113,7 @@ TiDB Ansible 版本：3.0.0-rc.2
 
 + TiDB Binlog
     - Drainer 增加下游同步延迟监控项 `checkpoint_delay` [#594](https://github.com/pingcap/tidb-binlog/pull/594)
-    - 升级 Parser 版本，支持更多语法 [#608](https://github.com/pingcap/tidb-binlog/pull/608)
+
 + TiDB Lightning
     - 支持数据库合并，数据表合并同步功能 [#95](https://github.com/pingcap/tidb-lightning/pull/95)
     - 新增 KV 写入失败重试机制 [#176](https://github.com/pingcap/tidb-lightning/pull/176)


### PR DESCRIPTION
### Removal Reason
Checked with devs, tidb binlog doesn't upgrade the Parser in 3.0, it's in 2.1. So remove this note. 