### PR TITLE
TOC: remove a redundant level above migrate from aurora

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -42,8 +42,7 @@
     + 从 MySQL 迁移
       - [全量迁移](dev/how-to/migrate/from-mysql.md)
       - [增量复制](dev/how-to/migrate/incrementally-from-mysql.md)
-    + 从与 MySQL 兼容的数据库迁移数据
-      - [从 Amazon Aurora MySQL 迁移数据](dev/how-to/migrate/from-aurora.md)
+    - [从 Amazon Aurora MySQL 迁移数据](dev/how-to/migrate/from-aurora.md)
     - [从 CSV 迁移](tools/lightning/csv.md)
   + 运维
     - [Ansible 常见运维操作](dev/how-to/maintain/ansible-operations.md)


### PR DESCRIPTION
This PR removed a redundant level of TOC above "migrate from Aurora" PTAL @lilin90 