### PR TITLE
dev/how-to/, dev/reference: fix some links in the upgrade documents

### DIFF
--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md) 以及[集群模式的 TiDB-Binlog](/tools/binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)。
 
 ## 升级兼容性说明
 

--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/dev/how-to/upgrade/to-tidb-2.1.md
+++ b/dev/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/dev/how-to/upgrade/to-tidb-2.1.md
+++ b/dev/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md)，须参考 [Binlog 升级方法](/tools/binlog/upgrade.md)升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/dev/reference/tidb-binlog-overview.md
+++ b/dev/reference/tidb-binlog-overview.md
@@ -57,7 +57,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     

--- a/dev/reference/tools/tidb-binlog/tidb-binlog-kafka.md
+++ b/dev/reference/tools/tidb-binlog/tidb-binlog-kafka.md
@@ -20,7 +20,7 @@ TiDB Binlog 支持以下功能场景:
 
 首先介绍 TiDB Binlog 的整体架构。
 
-![TiDB-Binlog 架构](/media/tidb_binlog_kafka_architecture.png)
+![TiDB Binlog 架构](/media/tidb_binlog_kafka_architecture.png)
 
 TiDB Binlog 集群主要分为三个组件：
 

--- a/v2.1/how-to/upgrade/from-previous-version.md
+++ b/v2.1/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md) 以及[集群模式的 TiDB-Binlog](/tools/binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[集群模式的 TiDB Binlog](/how-to/upgrade/tidb-binlog.md)。
 
 ## 升级兼容性说明
 

--- a/v2.1/how-to/upgrade/from-previous-version.md
+++ b/v2.1/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[集群模式的 TiDB Binlog](/how-to/upgrade/tidb-binlog.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/v2.1/how-to/upgrade/to-tidb-2.1.md
+++ b/v2.1/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md)，须参考 [Binlog 升级方法](/tools/binlog/upgrade.md)升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/v2.1/reference/tidb-binlog-overview.md
+++ b/v2.1/reference/tidb-binlog-overview.md
@@ -14,7 +14,7 @@ TiDB Binlog 支持以下功能场景：
 
 ## TiDB Binlog 整体架构
 
-![TiDB-Binlog 架构](/media/tidb_binlog_cluster_architecture.png)
+![TiDB Binlog 架构](/media/tidb_binlog_cluster_architecture.png)
 
 TiDB Binlog 集群主要分为 Pump 和 Drainer 两个组件，以及 binlogctl 工具：
 

--- a/v2.1/reference/tidb-binlog-overview.md
+++ b/v2.1/reference/tidb-binlog-overview.md
@@ -57,7 +57,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     

--- a/v3.0/how-to/upgrade/from-previous-version.md
+++ b/v3.0/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v3.0-upgrade-guide/']
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本升级方法](/tools/binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/v3.0/how-to/upgrade/from-previous-version.md
+++ b/v3.0/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v3.0-upgrade-guide/']
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md) 以及[集群模式的 TiDB-Binlog](/tools/binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本升级方法](/tools/binlog/overview.md)。
 
 ## 升级兼容性说明
 

--- a/v3.0/how-to/upgrade/rolling-updates-with-ansible.md
+++ b/v3.0/how-to/upgrade/rolling-updates-with-ansible.md
@@ -2,6 +2,7 @@
 title: 使用 TiDB-Ansible 升级 TiDB 集群
 category: how-to
 aliases: ['/docs-cn/op-guide/ansible-deployment-rolling-update/']
+
 ---
 
 # 使用 TiDB-Ansible 升级 TiDB 集群

--- a/v3.0/how-to/upgrade/tidb-binlog.md
+++ b/v3.0/how-to/upgrade/tidb-binlog.md
@@ -2,6 +2,7 @@
 title: TiDB Binlog Cluster 版本升级方法
 category: reference
 aliases: ['/docs-cn/tools/binlog/upgrade/','/docs-cn/dev/reference/tools/tidb-binlog/upgrade/']
+
 ---
 
 # TiDB Binlog Cluster 版本升级方法

--- a/v3.0/how-to/upgrade/to-tidb-2.1.md
+++ b/v3.0/how-to/upgrade/to-tidb-2.1.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v2.1-upgrade-guide/']
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/tools/binlog/tidb-binlog-kafka.md)，须参考 [Binlog 升级方法](/tools/binlog/upgrade.md)升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/v3.0/reference/tidb-binlog-overview.md
+++ b/v3.0/reference/tidb-binlog-overview.md
@@ -58,7 +58,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     

--- a/v3.0/reference/tools/tidb-binlog/tidb-binlog-kafka.md
+++ b/v3.0/reference/tools/tidb-binlog/tidb-binlog-kafka.md
@@ -21,7 +21,7 @@ TiDB Binlog 支持以下功能场景:
 
 首先介绍 TiDB Binlog 的整体架构。
 
-![TiDB-Binlog 架构](/media/tidb_binlog_kafka_architecture.png)
+![TiDB Binlog 架构](/media/tidb_binlog_kafka_architecture.png)
 
 TiDB Binlog 集群主要分为三个组件：
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
In the https://pingcap.com/docs-cn/v3.0/how-to/upgrade/from-previous-version/ and https://pingcap.com/docs-cn/v3.0/how-to/upgrade/to-tidb-2.1/ links of TiDB Binlog are out of date, so users will get 404 when they click these links. 
And also for the reparo link in the https://pingcap.com/docs-cn/v3.0/reference/tidb-binlog-overview/ .

So i changed the below: 
* Update TiDB Binlog links in **/how-to/upgrade/to-tidb-2.1/** and **/how-to/upgrade/from-previous-version/**
* Update Reparo link in **/reference/tidb-binlog-overview/**

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

Apply in dev/v3.0/v2.1. 
