### PR TITLE
dev, v3.0, v2.1: fix the wrong tidb binlog links

### DIFF
--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/dev/how-to/upgrade/tidb-binlog.md
+++ b/dev/how-to/upgrade/tidb-binlog.md
@@ -5,7 +5,7 @@ category: reference
 
 # TiDB Binlog Cluster 版本升级方法
 
-新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB-Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB-Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB-Binlog，必须将其升级到 Cluster 版本。
+新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB Binlog，必须将其升级到 Cluster 版本。
 
 TiDB Binlog 版本与 TiDB 版本的对应关系如下：
 

--- a/dev/how-to/upgrade/to-tidb-2.1.md
+++ b/dev/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/dev/reference/tidb-binlog-overview.md
+++ b/dev/reference/tidb-binlog-overview.md
@@ -57,7 +57,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/tidb-binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     

--- a/v2.1/how-to/upgrade/from-previous-version.md
+++ b/v2.1/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/v2.1/how-to/upgrade/tidb-binlog.md
+++ b/v2.1/how-to/upgrade/tidb-binlog.md
@@ -5,7 +5,7 @@ category: reference
 
 # TiDB Binlog Cluster 版本升级方法
 
-新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB-Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB-Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB-Binlog，必须将其升级到 Cluster 版本。
+新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB Binlog，必须将其升级到 Cluster 版本。
 
 TiDB Binlog 版本与 TiDB 版本的对应关系如下：
 

--- a/v2.1/how-to/upgrade/to-tidb-2.1.md
+++ b/v2.1/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/v2.1/how-to/upgrade/to-tidb-2.1.md
+++ b/v2.1/how-to/upgrade/to-tidb-2.1.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB-Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB-Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md) 升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/v2.1/reference/tidb-binlog-overview.md
+++ b/v2.1/reference/tidb-binlog-overview.md
@@ -57,7 +57,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/tidb-binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     

--- a/v3.0/how-to/upgrade/from-previous-version.md
+++ b/v3.0/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v3.0-upgrade-guide/']
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/reference/tidb-binlog-overview.md)。
 
 ## 升级兼容性说明
 

--- a/v3.0/how-to/upgrade/tidb-binlog.md
+++ b/v3.0/how-to/upgrade/tidb-binlog.md
@@ -7,7 +7,7 @@ aliases: ['/docs-cn/tools/binlog/upgrade/','/docs-cn/dev/reference/tools/tidb-bi
 
 # TiDB Binlog Cluster 版本升级方法
 
-新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB-Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB-Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB-Binlog，必须将其升级到 Cluster 版本。
+新版本的 TiDB（v2.0.8-binlog、v2.1.0-rc.5 及以上版本）不兼容 [Kafka 版本](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)以及 [Local 版本](/reference/tools/tidb-binlog/tidb-binlog-local.md)的 TiDB Binlog，集群升级到新版本后只能使用 Cluster 版本的 TiDB Binlog。如果在升级前已经使用了 Kafka／Local 版本的 TiDB Binlog，必须将其升级到 Cluster 版本。
 
 TiDB Binlog 版本与 TiDB 版本的对应关系如下：
 

--- a/v3.0/how-to/upgrade/to-tidb-2.1.md
+++ b/v3.0/how-to/upgrade/to-tidb-2.1.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v2.1-upgrade-guide/']
 
 # TiDB 2.1 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)升级到 Cluster 版本。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 2.1 GA 版本。TiDB 2.1 版本不兼容 Kafka 版本的 TiDB Binlog，如果当前集群已经使用 [Kafka 版本的 TiDB Binlog](/reference/tools/tidb-binlog/tidb-binlog-kafka.md)，须参考 [TiDB Binlog Cluster 版本升级方法](/how-to/upgrade/tidb-binlog.md)升级到 Cluster 版本。
 
 ## 升级兼容性说明
 

--- a/v3.0/reference/tidb-binlog-overview.md
+++ b/v3.0/reference/tidb-binlog-overview.md
@@ -58,7 +58,7 @@ Pump 和 Drainer 都支持部署和运行在 Intel x86-64 架构的 64 位通用
 
 * Drainer 支持将 Binlog 同步到 MySQL、TiDB、Kafka 或者本地文件。如果需要将 Binlog 同步到其他 Drainer 不支持的类型的系统中，可以设置 Drainer 将 Binlog 同步到 Kafka，然后根据 binlog slave protocol 进行定制处理，参考 [binlog slave client 用户文档](/reference/tools/tidb-binlog/binlog-slave-client.md)。
 
-* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/binlog/reparo.md) 恢复增量数据。
+* 如果 TiDB Binlog 用于增量恢复，可以设置配置项 `db-type="file"`，Drainer 会将 binlog 转化为指定的 [proto buffer 格式](https://github.com/pingcap/tidb-binlog/blob/master/proto/binlog.proto)的数据，再写入到本地文件中。这样就可以使用 [Reparo](/reference/tools/tidb-binlog/reparo.md) 恢复增量数据。
 
     关于 `db-type` 的取值，应注意：
     


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
The kafka binlog links in https://pingcap.com/docs-cn/v3.0/how-to/upgrade/from-previous-version/ and https://pingcap.com/docs-cn/v3.0/how-to/upgrade/to-tidb-2.1/ are wrong, should be correct to `/reference/tools/tidb-binlog/tidb-binlog-kafka.md`

The Reparo link in https://pingcap.com/docs-cn/v3.0/reference/tidb-binlog-overview/ is wrong , should be correct to `/reference/tools/tidb-binlog/reparo.md`

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

Apply to 3.0/2.1/dev
