### PR TITLE
tidb-in-kubernetes/maintain-node: fix typo and empty command

### DIFF
--- a/tidb-in-kubernetes/maintain-node.md
+++ b/tidb-in-kubernetes/maintain-node.md
@@ -115,10 +115,10 @@ kubectl port-forward svc/${CLUSTER_NAME}-pd 2379:2379
 {{< copyable "shell-regular" >}}
 
 ```shell
-pd-ctl -d 
+pd-ctl -d config set max-store-down-time 10m
 ```
 
-调整 `max-store-donw-time` 到合理的值后，后续的操作方式与[维护 PD 和 TiDB 实例所在节点](#维护-pd-和-tidb-实例所在节点)相同。 
+调整 `max-store-down-time` 到合理的值后，后续的操作方式与[维护 PD 和 TiDB 实例所在节点](#维护-pd-和-tidb-实例所在节点)相同。 
 
 ### 维护短期内不可恢复的节点
 


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Fix typo and empty command in maintain-node documentation

<!--Tell us what you did and why.-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`

@yikeke @tennix PTAL