### PR TITLE
dev, v3.0: fix incorrect links

### DIFF
--- a/dev/reference/configuration/tikv-server/configuration-file.md
+++ b/dev/reference/configuration/tikv-server/configuration-file.md
@@ -7,7 +7,7 @@ category: reference
 
 TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/config-template.toml](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) 找到默认值的配置文件，重命名为 config.toml 即可。
 
-本文档只阐述未包含在命令行参数中的参数，命令行参数参见[这里](/dev/reference/configuration/tikv-server/configuration.md)。
+本文档只阐述未包含在命令行参数中的参数，命令行参数参见[这里](/reference/configuration/tikv-server/configuration.md)。
 
 ### `status-thread-pool-size`
 

--- a/dev/reference/system-databases/information-schema.md
+++ b/dev/reference/system-databases/information-schema.md
@@ -28,7 +28,7 @@ mysql> select * from `ANALYZE_STATUS`
 
 ## CHARACTER_SETS Table
 
-`CHARACTER_SETS` 表提供[字符集](/dev/reference/sql/character-set.md)相关的信息。TiDB 目前仅支持部分字符集。
+`CHARACTER_SETS` 表提供[字符集](/reference/sql/character-set.md)相关的信息。TiDB 目前仅支持部分字符集。
 
 ```sql
 mysql> SELECT * FROM character_sets;

--- a/v3.0/reference/configuration/tikv-server/configuration-file.md
+++ b/v3.0/reference/configuration/tikv-server/configuration-file.md
@@ -7,7 +7,7 @@ category: reference
 
 TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/config-template.toml](https://github.com/tikv/tikv/blob/master/etc/config-template.toml) 找到默认值的配置文件，重命名为 config.toml 即可。
 
-本文档只阐述未包含在命令行参数中的参数，命令行参数参见[这里](/dev/reference/configuration/tikv-server/configuration.md)。
+本文档只阐述未包含在命令行参数中的参数，命令行参数参见[这里](/reference/configuration/tikv-server/configuration.md)。
 
 ### `status-thread-pool-size`
 

--- a/v3.0/reference/system-databases/information-schema.md
+++ b/v3.0/reference/system-databases/information-schema.md
@@ -29,7 +29,7 @@ mysql> select * from `ANALYZE_STATUS`
 
 ## CHARACTER_SETS Table
 
-`CHARACTER_SETS` 表提供[字符集](/dev/reference/sql/character-set.md)相关的信息。TiDB 目前仅支持部分字符集。
+`CHARACTER_SETS` 表提供[字符集](/reference/sql/character-set.md)相关的信息。TiDB 目前仅支持部分字符集。
 
 ```sql
 mysql> SELECT * FROM character_sets;


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.--> fix incorrect links in dev and v3.0 folders @CaitinChen  PTAL

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->
dev and v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`