### PR TITLE
dev, v2.1, v3.0: remove shared block cache from 2.1

### DIFF
--- a/dev/reference/performance/tune-tikv.md
+++ b/dev/reference/performance/tune-tikv.md
@@ -21,9 +21,11 @@ TiKV 使用了 RocksDB 的 `Column Families` (CF) 特性。
 
     - `default` CF 主要存储的是 Raft log，与其对应的参数位于 `[raftdb.defaultcf]` 项中。
 
-在 TiKV 3.0 版本后，所有的 CF 默认共同使用一个 block cache 实例。通过在 `[storage.block-cache]` 下设置 `capacity` 参数，你可以配置该 block cache 的大小。block cache 越大，能够缓存的热点数据越多，读取数据越容易，同时占用的系统内存也越多。如果要为每个 CF 使用单独的 block cache 实例，需要在 `[storage.block-cache]` 下设置 `shared=false`，并为每个 CF 配置单独的 block cache 大小。例如，可以在 `[rocksdb.writecf]` 下设置 `block-cache-size` 参数来配置 `write` CF 的大小。
+所有的 CF 默认共同使用一个 block cache 实例。通过在 `[storage.block-cache]` 下设置 `capacity` 参数，你可以配置该 block cache 的大小。block cache 越大，能够缓存的热点数据越多，读取数据越容易，同时占用的系统内存也越多。如果要为每个 CF 使用单独的 block cache 实例，需要在 `[storage.block-cache]` 下设置 `shared=false`，并为每个 CF 配置单独的 block cache 大小。例如，可以在 `[rocksdb.writecf]` 下设置 `block-cache-size` 参数来配置 `write` CF 的大小。
 
-在 TiKV 3.0 之前的版本中，不支持使用 `shared block cache`，因此需要为每个 CF 单独配置 block cache。
+> **注意：**
+>
+> 在 TiKV 3.0 之前的版本中，不支持使用 `shared block cache`，需要为每个 CF 单独配置 block cache。
 
 每个 CF 有各自的 `write-buffer`，大小通过 `write-buffer-size` 控制。
 

--- a/v2.1/reference/key-monitoring-metrics/tikv-dashboard.md
+++ b/v2.1/reference/key-monitoring-metrics/tikv-dashboard.md
@@ -357,7 +357,7 @@ category: reference
 - Write stall duration：由于 write stall 造成的时间开销，正常情况下应为 0
 - Memtable size：每个 CF 的 memtable 的大小
 - Memtable hit：memtable 的命中率
-- Block cache size：block cache 的大小。如果将 `shared block cache` 禁用，即为每个 CF 的 block cache 的大小
+- Block cache size：block cache 的大小
 - Block cache hit：block cache 的命中率
 - Block cache flow：不同 block cache 操作的流量
 - Block cache operations 不同 block cache 操作的个数
@@ -393,7 +393,7 @@ category: reference
 - Write stall duration：由于 write stall 造成的时间开销，正常情况下应为 0
 - Memtable size：每个 CF 的 memtable 的大小
 - Memtable hit：memtable 的命中率
-- Block cache size：block cache 的大小。如果将 `shared block cache` 禁用，即为每个 CF 的 block cache 的大小
+- Block cache size：block cache 的大小
 - Block cache hit：block cache 的命中率
 - Block cache flow：不同 block cache 操作的流量
 - Block cache operations 不同 block cache 操作的个数

--- a/v2.1/reference/performance/tune-tikv.md
+++ b/v2.1/reference/performance/tune-tikv.md
@@ -194,7 +194,7 @@ max-bytes-for-level-base = "512MB"
 target-file-size-base = "32MB"
 
 # 在不配置该参数的情况下，TiKV 会将该值设置为系统总内存量的 15%。如果需要在单个物理机上部署多个
-# TiKV 节点，需要显式配置该参数。版本信息（MVCC）相关的数据以及索引相关的数据都记录在 write 这
+# TiKV 节点，需要显式配置该参数。版本信息 (MVCC) 相关的数据以及索引相关的数据都记录在 write 这
 # 个 CF 里面，如果业务的场景下单表索引较多，可以将该参数设置的更大一点。
 # block-cache-size = "256MB"
 

--- a/v2.1/reference/performance/tune-tikv.md
+++ b/v2.1/reference/performance/tune-tikv.md
@@ -21,7 +21,7 @@ TiKV 使用了 RocksDB 的 `Column Families` (CF) 特性。
 
     - `default` CF 主要存储的是 Raft log，与其对应的参数位于 `[raftdb.defaultcf]` 项中。
 
-每个 CF 都有单独的 `block-cache`，用于缓存数据块，加速 RocksDB 的读取速度，block-cache 的大小通过参数 `block-cache-size` 控制，block-cache-size 越大，能够缓存的热点数据越多，对读取操作越有利，同时占用的系统内存也会越多。
+每个 CF 都有单独的 `block-cache`，用于缓存数据块，加速 RocksDB 的读取速度，block-cache 的大小通过参数 `block-cache-size` 控制，`block-cache-size` 越大，能够缓存的热点数据越多，对读取操作越有利，同时占用的系统内存也会越多。
 
 每个 CF 有各自的 `write-buffer`，大小通过 `write-buffer-size` 控制。
 

--- a/v2.1/reference/tools/tikv-control.md
+++ b/v2.1/reference/tools/tikv-control.md
@@ -205,18 +205,14 @@ $ tikv-ctl --host 127.0.0.1:20160 region-properties -r 2
 
 使用 `modify-tikv-config` 命令可以动态修改配置参数，暂时仅支持对于 RocksDB 相关参数的动态更改。
 
-- `-m` 用于指定要修改的模块，有 `storage`、`kvdb` 和 `raftdb` 三个值可以选择。
-- `-n` 用于指定配置名。配置名可以参考 [TiKV 配置模版](https://github.com/pingcap/tikv/blob/master/etc/config-template.toml#L213-L500)中 `[storage]`、`[rocksdb]` 和 `[raftdb]` 下的参数，分别对应 `storage`、`kvdb` 和 `raftdb`。同时，还可以通过 `default|write|lock + . + 参数名` 的形式来指定的不同 CF 的配置。对于 `kvdb` 有 `default`、`write` 和 `lock` 可以选择，对于 `raftdb` 仅有 `default` 可以选择。
+- `-m` 用于指定要修改的 RocksDB，有 `kvdb` 和 `raftdb` 两个值可以选择。
+- `-n` 用于指定配置名。配置名可以参考 [TiKV 配置模版](https://github.com/pingcap/tikv/blob/master/etc/config-template.toml#L213-L500)中 `[rocksdb]` 和 `[raftdb]` 下的参数，分别对应 `kvdb` 和 `raftdb`。同时，还可以通过 `default|write|lock + . + 参数名` 的形式来指定的不同 CF 的配置。对于 `kvdb` 有 `default`、`write` 和 `lock` 可以选择，对于 `raftdb` 仅有 `default` 可以选择。
 - `-v` 用于指定配置值。
 
 ```bash
-# 设置 `shared block cache` 的大小。
-$ tikv-ctl modify-tikv-config -m storage -n block_cache.capacity -v 10GB
-success!
-# 当禁用 `shared block cache` 时，为 `write` CF 设置 `block cache size`。
-$ tikv-ctl modify-tikv-config -m kvdb -n write.block_cache_size -v 256MB
-success!
 $ tikv-ctl modify-tikv-config -m kvdb -n max_background_jobs -v 8
+success!
+$ tikv-ctl modify-tikv-config -m kvdb -n write.block-cache-size -v 256MB
 success!
 $ tikv-ctl modify-tikv-config -m raftdb -n default.disable_auto_compactions -v true
 success!

--- a/v3.0/reference/performance/tune-tikv.md
+++ b/v3.0/reference/performance/tune-tikv.md
@@ -22,9 +22,11 @@ TiKV 使用了 RocksDB 的 `Column Families` (CF) 特性。
 
     - `default` CF 主要存储的是 Raft log，与其对应的参数位于 `[raftdb.defaultcf]` 项中。
 
-在 TiKV 3.0 版本后，所有的 CF 默认共同使用一个 block cache 实例。通过在 `[storage.block-cache]` 下设置 `capacity` 参数，你可以配置该 block cache 的大小。block cache 越大，能够缓存的热点数据越多，读取数据越容易，同时占用的系统内存也越多。如果要为每个 CF 使用单独的 block cache 实例，需要在 `[storage.block-cache]` 下设置 `shared=false`，并为每个 CF 配置单独的 block cache 大小。例如，可以在 `[rocksdb.writecf]` 下设置 `block-cache-size` 参数来配置 `write` CF 的大小。
+所有的 CF 默认共同使用一个 block cache 实例。通过在 `[storage.block-cache]` 下设置 `capacity` 参数，你可以配置该 block cache 的大小。block cache 越大，能够缓存的热点数据越多，读取数据越容易，同时占用的系统内存也越多。如果要为每个 CF 使用单独的 block cache 实例，需要在 `[storage.block-cache]` 下设置 `shared=false`，并为每个 CF 配置单独的 block cache 大小。例如，可以在 `[rocksdb.writecf]` 下设置 `block-cache-size` 参数来配置 `write` CF 的大小。
 
-在 TiKV 3.0 之前的版本中，不支持使用 `shared block cache`，因此需要为每个 CF 单独配置 block cache。
+> **注意：**
+>
+> 在 TiKV 3.0 之前的版本中，不支持使用 `shared block cache`，需要为每个 CF 单独配置 block cache。
 
 每个 CF 有各自的 `write-buffer`，大小通过 `write-buffer-size` 控制。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

- Remove the inapplicable shared block cache description from `v2.1` (change it back for 2.1)
- Update description in `dev` and `v3.0`

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

https://github.com/pingcap/docs-cn/pull/1329

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

dev, v3.0, v2.1

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
