### PR TITLE
v3.0, dev/reference: fix a broken link in TiDB operator overview

### DIFF
--- a/dev/reference/tidb-operator-overview.md
+++ b/dev/reference/tidb-operator-overview.md
@@ -46,7 +46,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
 
 部署完成后，你可以参考下面的文档进行 Kubernetes 上 TiDB 集群的使用和运维：
 
-+ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration/)
++ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration.md)
 + [访问 TiDB 集群](how-to/deploy/tidb-in-kubernetes/access-tidb.md)
 + [TiDB 集群扩缩容](how-to/scale/tidb-in-kubernetes.md)
 + [TiDB 集群升级](how-to/upgrade/tidb-in-kubernetes.md#升级-tidb-版本)

--- a/dev/reference/tidb-operator-overview.md
+++ b/dev/reference/tidb-operator-overview.md
@@ -46,7 +46,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
 
 部署完成后，你可以参考下面的文档进行 Kubernetes 上 TiDB 集群的使用和运维：
 
-+ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration.md)
++ [管理 TiDB 集群](how-to/maintain/tidb-in-kubernetes/k8s-node-for-tidb.md)
 + [访问 TiDB 集群](how-to/deploy/tidb-in-kubernetes/access-tidb.md)
 + [TiDB 集群扩缩容](how-to/scale/tidb-in-kubernetes.md)
 + [TiDB 集群升级](how-to/upgrade/tidb-in-kubernetes.md#升级-tidb-版本)

--- a/v3.0/reference/tidb-operator-overview.md
+++ b/v3.0/reference/tidb-operator-overview.md
@@ -46,7 +46,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
 
 部署完成后，你可以参考下面的文档进行 Kubernetes 上 TiDB 集群的使用和运维：
 
-+ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration/)
++ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration.md)
 + [访问 TiDB 集群](how-to/deploy/tidb-in-kubernetes/access-tidb.md)
 + [TiDB 集群扩缩容](how-to/scale/tidb-in-kubernetes.md)
 + [TiDB 集群升级](how-to/upgrade/tidb-in-kubernetes.md#升级-tidb-版本)

--- a/v3.0/reference/tidb-operator-overview.md
+++ b/v3.0/reference/tidb-operator-overview.md
@@ -46,7 +46,7 @@ TiDB Operator 提供了多种方式来部署 Kubernetes 上的 TiDB 集群：
 
 部署完成后，你可以参考下面的文档进行 Kubernetes 上 TiDB 集群的使用和运维：
 
-+ [管理 TiDB 集群](reference/configuration/tidb-in-kubernetes/cluster-configuration.md)
++ [管理 TiDB 集群](how-to/maintain/tidb-in-kubernetes/k8s-node-for-tidb.md)
 + [访问 TiDB 集群](how-to/deploy/tidb-in-kubernetes/access-tidb.md)
 + [TiDB 集群扩缩容](how-to/scale/tidb-in-kubernetes.md)
 + [TiDB 集群升级](how-to/upgrade/tidb-in-kubernetes.md#升级-tidb-版本)


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR fixes a broken link in the `TiDB Operator Overview` document.

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

`v3.0` `dev`

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
