### PR TITLE
tidb-in-kubernetes/*/backup: fix bad links

### DIFF
--- a/dev/reference/configuration/tidb-in-kubernetes/backup-configuration.md
+++ b/dev/reference/configuration/tidb-in-kubernetes/backup-configuration.md
@@ -52,13 +52,13 @@ category: reference
 
 + 备份参数
 + 默认："--chunk-filesize=100"
-+ 为备份数据时使用的 [mydumper](/dev/reference/tools/mydumper.md) 指定额外的运行参数
++ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options)) 指定额外的运行参数
 
 ## `restoreOptions`
 
 + 恢复参数
 + 默认："-t 16"
-+ 为恢复数据时使用的 [Loader](/dev/reference/tools/loader.md) 指定额外的运行参数
++ 为恢复数据时使用的 [Loader](/reference/tools/loader.md) 指定额外的运行参数
 
 ## `gcp.bucket`
 

--- a/dev/reference/configuration/tidb-in-kubernetes/backup-configuration.md
+++ b/dev/reference/configuration/tidb-in-kubernetes/backup-configuration.md
@@ -52,7 +52,7 @@ category: reference
 
 + 备份参数
 + 默认："--chunk-filesize=100"
-+ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options)) 指定额外的运行参数
++ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options) 指定额外的运行参数
 
 ## `restoreOptions`
 

--- a/v3.0/reference/configuration/tidb-in-kubernetes/backup-configuration.md
+++ b/v3.0/reference/configuration/tidb-in-kubernetes/backup-configuration.md
@@ -52,13 +52,13 @@ category: reference
 
 + 备份参数
 + 默认："--chunk-filesize=100"
-+ 为备份数据时使用的 [mydumper](/dev/reference/tools/mydumper.md) 指定额外的运行参数
++ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options)) 指定额外的运行参数
 
 ## `restoreOptions`
 
 + 恢复参数
 + 默认："-t 16"
-+ 为恢复数据时使用的 [Loader](/dev/reference/tools/loader.md) 指定额外的运行参数
++ 为恢复数据时使用的 [Loader](/reference/tools/loader.md) 指定额外的运行参数
 
 ## `gcp.bucket`
 

--- a/v3.0/reference/configuration/tidb-in-kubernetes/backup-configuration.md
+++ b/v3.0/reference/configuration/tidb-in-kubernetes/backup-configuration.md
@@ -52,7 +52,7 @@ category: reference
 
 + 备份参数
 + 默认："--chunk-filesize=100"
-+ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options)) 指定额外的运行参数
++ 为备份数据时使用的 [mydumper](https://github.com/maxbube/mydumper/blob/master/docs/mydumper_usage.rst#options) 指定额外的运行参数
 
 ## `restoreOptions`
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

This PR fixed two links.


### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

TiDB 3.0/Dev

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
