### PR TITLE
tidb-server: rename tidb_back_off_weight to tidb_backoff_weight

### DIFF
--- a/dev/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/dev/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -363,15 +363,15 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 是否需要禁用自动重试，请参考[自动重试的风险](/reference/transactions/transaction-isolation.md#乐观事务注意事项)。
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 作用域：SESSION | GLOBAL
 
 默认值：2
 
-这个变量用来给 TiDB 的 `back-off` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
+这个变量用来给 TiDB 的 `backoff` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
 
-例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_back_off_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
+例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_backoff_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
 
 在网络环境较差的情况下，适当增大该变量值可以有效缓解因为超时而向应用端报错的情况；而如果应用端希望更快地接到报错信息，则应该尽量减小该变量的值。
 

--- a/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v2.1/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -331,15 +331,15 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 是否需要禁用自动重试，请参考[自动重试的风险](/reference/transactions/transaction-isolation.md#乐观事务注意事项)。
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 作用域：SESSION | GLOBAL
 
 默认值：2
 
-这个变量用来给 TiDB 的 `back-off` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
+这个变量用来给 TiDB 的 `backoff` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
 
-例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_back_off_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
+例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_backoff_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
 
 在网络环境较差的情况下，适当增大该变量值可以有效缓解因为超时而向应用端报错的情况；而如果应用端希望更快地接到报错信息，则应该尽量减小该变量的值。
 

--- a/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/v3.0/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -365,15 +365,15 @@ set @@global.tidb_distsql_scan_concurrency = 10
 
 是否需要禁用自动重试，请参考[自动重试的风险](/reference/transactions/transaction-isolation.md#乐观事务注意事项)。
 
-### tidb_back_off_weight
+### tidb_backoff_weight
 
 作用域：SESSION | GLOBAL
 
 默认值：2
 
-这个变量用来给 TiDB 的 `back-off` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
+这个变量用来给 TiDB 的 `backoff` 最大时间增加权重，即内部遇到网络或其他组件（TiKV、PD）故障等时，发送重试请求的最大重试时间。可以通过这个变量来调整最大重试时间，最小值为 1。
 
-例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_back_off_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
+例如，TiDB 向 PD 取 TSO 的基础超时时间是 15 秒，当 `tidb_backoff_weight = 2` 时，取 TSO 的最大超时时间为：基础时间 * 2 等于 30 秒。
 
 在网络环境较差的情况下，适当增大该变量值可以有效缓解因为超时而向应用端报错的情况；而如果应用端希望更快地接到报错信息，则应该尽量减小该变量的值。
 


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Rename `tidb_back_off_weight` to `tidb_backoff_weight` to make it consistent with `tidb_backoff_lock_fast`.
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [x] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
