### PR TITLE
dev/releases, v3.0/releases: fix the 3.0.2 tidb binlog releaes mistake

### DIFF
--- a/dev/releases/3.0.2.md
+++ b/dev/releases/3.0.2.md
@@ -118,7 +118,7 @@ TiDB Ansible 版本：3.0.2
 TiDB Binlog
 
 - 增加启动时配置项检查功能，遇到不合法配置项会退出运行并给出错误信息 [#687](https://github.com/pingcap/tidb-binlog/pull/687)
-- Drainer 增加 `note-id` 配置，用于指定固定逻辑 Drainer [#684](https://github.com/pingcap/tidb-binlog/pull/684)
+- Drainer 增加 `node-id` 配置，用于指定固定逻辑 Drainer [#684](https://github.com/pingcap/tidb-binlog/pull/684)
 
 TiDB Lightning
 

--- a/v3.0/releases/3.0.2.md
+++ b/v3.0/releases/3.0.2.md
@@ -118,7 +118,7 @@ TiDB Ansible 版本：3.0.2
 TiDB Binlog
 
 - 增加启动时配置项检查功能，遇到不合法配置项会退出运行并给出错误信息 [#687](https://github.com/pingcap/tidb-binlog/pull/687)
-- Drainer 增加 `note-id` 配置，用于指定固定逻辑 Drainer [#684](https://github.com/pingcap/tidb-binlog/pull/684)
+- Drainer 增加 `node-id` 配置，用于指定固定逻辑 Drainer [#684](https://github.com/pingcap/tidb-binlog/pull/684)
 
 TiDB Lightning
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->
The release in TiDB Binlog has a mistake in 
```
Add the node-id configuration in Drainer to specify a specific logic used by Drainer
```
The configuration should be `node-id` rather than `note-id`

### What is the related PR or file link(s)? <!--REMOVE this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

V3.0, Dev

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [ ] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
