### PR TITLE
dev/reference, v3.0/reference, v2.1/reference: DM doc issue fix

### DIFF
--- a/dev/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/dev/reference/tools/data-migration/configure/task-configuration-file.md
@@ -129,7 +129,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: mysql-bin.000001
+      binlog-name: binlog.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/dev/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/dev/reference/tools/data-migration/configure/task-configuration-file.md
@@ -129,7 +129,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: binlog-00001
+      binlog-name: mysql-bin.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/dev/reference/tools/data-migration/dm-portal.md
+++ b/dev/reference/tools/data-migration/dm-portal.md
@@ -44,7 +44,7 @@ category: reference
 
 ## 部署使用
 
-### Binarey 部署
+### Binary 部署
 
 DM Portal 可以在 [dm-portal-latest-linux-amd64.tar.gz](https://download.pingcap.org/dm-portal-latest-linux-amd64.tar.gz) 下载，通过 `./dm-portal` 的命令即可直接启动。
 

--- a/v2.1/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/v2.1/reference/tools/data-migration/configure/task-configuration-file.md
@@ -129,7 +129,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: mysql-bin.000001
+      binlog-name: binlog.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/v2.1/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/v2.1/reference/tools/data-migration/configure/task-configuration-file.md
@@ -129,7 +129,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: binlog-00001
+      binlog-name: mysql-bin.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/v2.1/reference/tools/data-migration/dm-portal.md
+++ b/v2.1/reference/tools/data-migration/dm-portal.md
@@ -44,7 +44,7 @@ category: reference
 
 ## 部署使用
 
-### Binarey 部署
+### Binary 部署
 
 DM Portal 可以在 [dm-portal-latest-linux-amd64.tar.gz](https://download.pingcap.org/dm-portal-latest-linux-amd64.tar.gz) 下载，通过 `./dm-portal` 的命令即可直接启动。
 

--- a/v3.0/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/v3.0/reference/tools/data-migration/configure/task-configuration-file.md
@@ -130,7 +130,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: mysql-bin.000001
+      binlog-name: binlog.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/v3.0/reference/tools/data-migration/configure/task-configuration-file.md
+++ b/v3.0/reference/tools/data-migration/configure/task-configuration-file.md
@@ -130,7 +130,7 @@ mysql-instances:
   -
     source-id: "mysql-replica-01"           # 上游实例或者复制组 ID，参考 `inventory.ini` 的 `source_id` 或者 `dm-master.toml` 的 `source-id` 配置。
     meta:                                   # `task-mode` 为 `incremental` 且下游数据库的 `checkpoint` 不存在时 binlog 同步开始的位置; 如果 checkpoint 存在，则以 `checkpoint` 为准。
-      binlog-name: binlog-00001
+      binlog-name: mysql-bin.000001
       binlog-pos: 4
 
     route-rules: ["route-rule-1", "route-rule-2"]    # 该上游数据库实例匹配的表到下游数据库的 table routing 规则名称。

--- a/v3.0/reference/tools/data-migration/dm-portal.md
+++ b/v3.0/reference/tools/data-migration/dm-portal.md
@@ -44,7 +44,7 @@ category: reference
 
 ## 部署使用
 
-### Binarey 部署
+### Binary 部署
 
 DM Portal 可以在 [dm-portal-latest-linux-amd64.tar.gz](https://download.pingcap.org/dm-portal-latest-linux-amd64.tar.gz) 下载，通过 `./dm-portal` 的命令即可直接启动。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->

1. Fix the typo in DM Portal
2. Fix the mistake in DM task configuration file

### Which version does your change affect? <!--REMOVE this item if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

dev, v3.0, v2.1

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [ ] Leave a blank line both before and after a code block
- [ ] Keep the first level heading consistent with `title` in metadata
- [ ] Use *four* spaces for each level of indentation except that in `TOC.md`
