### PR TITLE
reference/sql: add declaration for utf8 charset checking

### DIFF
--- a/dev/reference/sql/character-set.md
+++ b/dev/reference/sql/character-set.md
@@ -253,4 +253,10 @@ SET collation_connection = @@collation_database;
 * 规则2:    指定 CHARACTER SET charset_name 且未指定 COLLATE collation_name，则使用 CHARACTER SET charset_name 和 CHARACTER SET charset_name 默认的排序比较规则。
 * 规则3:   CHARACTER SET charset_name 和 COLLATE collation_name 都未指定，则使用更高优化级给出的字符集和排序比较规则。
 
+## 字符合法性检查
+
+当指定的字符集为 utf8 或 utf8mb4 时，TiDB 仅支持合法的 utf8 字符。对于不合法的字符，会报错：`incorrect utf8 value`。
+
+如果不希望报错，可以通过 `set @@tidb_skip_utf8_check=1;` 跳过字符检查。
+
 更多细节，参考 [Connection Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-connection.html)。

--- a/v2.1/reference/sql/character-set.md
+++ b/v2.1/reference/sql/character-set.md
@@ -199,6 +199,7 @@ SET character_set_client = charset_name;
 SET character_set_results = charset_name;
 SET character_set_connection = charset_name;
 ```
+
 `COLLATE` 是可选的，如果没有提供，将会用 charset_name 默认的 Collation。
 
 * `SET CHARACTER SET 'charset_name'`

--- a/v2.1/reference/sql/character-set.md
+++ b/v2.1/reference/sql/character-set.md
@@ -211,4 +211,10 @@ SET character_set_results = charset_name;
 SET collation_connection = @@collation_database;
 ```
 
+## 字符合法性检查
+
+当指定的字符集为 utf8 或 utf8mb4 时，TiDB 仅支持合法的 utf8 字符。对于不合法的字符，会报错：`incorrect utf8 value`。
+
+如果不希望报错，可以通过 `set @@tidb_skip_utf8_check=1;` 跳过字符检查。
+
 更多细节，参考 [Connection Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-connection.html)。

--- a/v3.0/reference/sql/character-set.md
+++ b/v3.0/reference/sql/character-set.md
@@ -260,5 +260,4 @@ SET collation_connection = @@collation_database;
 
 如果不希望报错，可以通过 `set @@tidb_skip_utf8_check=1;` 跳过字符检查。
 
-
 更多细节，参考 [Connection Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-connection.html)。

--- a/v3.0/reference/sql/character-set.md
+++ b/v3.0/reference/sql/character-set.md
@@ -254,4 +254,11 @@ SET collation_connection = @@collation_database;
 * 规则2:    指定 CHARACTER SET charset_name 且未指定 COLLATE collation_name，则使用 CHARACTER SET charset_name 和 CHARACTER SET charset_name 默认的排序比较规则。
 * 规则3:   CHARACTER SET charset_name 和 COLLATE collation_name 都未指定，则使用更高优化级给出的字符集和排序比较规则。
 
+## 字符合法性检查
+
+当指定的字符集为 utf8 或 utf8mb4 时，TiDB 仅支持合法的 utf8 字符。对于不合法的字符，会报错：`incorrect utf8 value`。
+
+如果不希望报错，可以通过 `set @@tidb_skip_utf8_check=1;` 跳过字符检查。
+
+
 更多细节，参考 [Connection Character Sets and Collations](https://dev.mysql.com/doc/refman/5.7/en/charset-connection.html)。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
Add declaration for character checking on utf8 charset, and the method for skipping the checking.

<!--Tell us what you did and why.-->
MySQL 5.7 has no check for character but MySQL 8.0 has. This could make confusion.

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->
https://github.com/pingcap/docs-cn/blob/master/v3.0/reference/sql/character-set.md

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

### Checklist <!--Check the box before the applicable item by using "- [x]"-->

- [ ] Add a new file to `TOC.md`
- [x] No Tab spaces anywhere <!--Use ordinary spaces because Tab spaces can lead to CircleCI failure.-->
- [x] Leave a blank line both before and after a code block
- [x] Keep the first level heading consistent with `title` in metadata
- [x] Use *four* spaces for each level of indentation except that in `TOC.md`
