### PR TITLE
how-to: optimize the explanation of ansible-excessive_rolling_update

### DIFF
--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -135,25 +135,21 @@ $ ansible-playbook local_prepare.yml
 
 ## 滚动升级 TiDB 集群组件
 
-> **注意：**
->
-> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。如当前版本**小于** TiDB 3.0 版本，滚动升级到 TiDB 3.0 版本集群组件的操作略有不同，注意升级前后 `process_supervision` 参数配置须保持一致。
-
-如果 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook excessive_rolling_update.yml
 ```
 
-> **注意：**
->
-> 如当前版本**大于或等于** TiDB 3.0 版本，则滚动升级及日常滚动重启 TiDB 集群仍然使用 `rolling_update.yml` 操作。
-
-如果 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook rolling_update.yml
 ```
+
+> **注意：**
+>
+> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。在升级到 TiDB 3.0 版本后，滚动升级及日常滚动重启 TiDB 集群统一使用 `rolling_update.yml` 操作，不再使用 `excessive_rolling_update.yml`。
 
 ## 滚动升级 TiDB 监控组件
 

--- a/v2.1/how-to/upgrade/from-previous-version.md
+++ b/v2.1/how-to/upgrade/from-previous-version.md
@@ -135,21 +135,21 @@ $ ansible-playbook local_prepare.yml
 
 ## 滚动升级 TiDB 集群组件
 
-> **注意：**
->
-> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。与之前版本相比，滚动升级 TiDB 3.0 版本集群组件的操作略有不同，注意升级前后 `process_supervision` 参数配置须保持一致。
-
-如果 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook excessive_rolling_update.yml
 ```
 
-如果 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook rolling_update.yml
 ```
+
+> **注意：**
+>
+> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。在升级到 TiDB 3.0 版本后，滚动升级及日常滚动重启 TiDB 集群统一使用 `rolling_update.yml` 操作，不再使用 `excessive_rolling_update.yml`。
 
 ## 滚动升级 TiDB 监控组件
 

--- a/v3.0/how-to/upgrade/from-previous-version.md
+++ b/v3.0/how-to/upgrade/from-previous-version.md
@@ -136,25 +136,21 @@ $ ansible-playbook local_prepare.yml
 
 ## 滚动升级 TiDB 集群组件
 
-> **注意：**
->
-> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。如当前版本**小于** TiDB 3.0 版本，滚动升级到 TiDB 3.0 版本集群组件的操作略有不同，注意升级前后 `process_supervision` 参数配置须保持一致。
-
-如果 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用默认的 `systemd` 参数，则通过 `excessive_rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook excessive_rolling_update.yml
 ```
 
-> **注意：**
->
-> 如当前版本**大于或等于** TiDB 3.0 版本，则滚动升级及日常滚动重启 TiDB 集群仍然使用 `rolling_update.yml` 操作。
-
-如果 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
+如果当前 `process_supervision` 变量使用 `supervise` 参数，则通过 `rolling_update.yml` 滚动升级 TiDB 集群。
 
 ```
 $ ansible-playbook rolling_update.yml
 ```
+
+> **注意：**
+>
+> 为优化 TiDB 集群组件的运维管理，TiDB 3.0 版本对 `systemd` 模式下的 `PD service` 名称进行了调整。在升级到 TiDB 3.0 版本后，滚动升级及日常滚动重启 TiDB 集群统一使用 `rolling_update.yml` 操作，不再使用 `excessive_rolling_update.yml`。
 
 ## 滚动升级 TiDB 监控组件
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why.-->

When users upgrading the TiDB from 2.1 to 3.0, may confuse the difference of `rolling_update` and `excessive_rolling_update ` and operate with mistake. 
So, i changed the the doc in **/how-to/upgrade/from-previous-version/**, optimize the explanation of `rolling_update` and `excessive_rolling_update `. 

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->

<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

N/A

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->

<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->

dev, v3.0, v2.1
