### PR TITLE
tidb-in-kubernetes/get-started: fix grep error on macOS

### DIFF
--- a/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -90,7 +90,7 @@ helm init
 {{< copyable "shell-regular" >}}
 
 ``` shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
 ```
 
 安装完成后，执行 `helm version` 会同时显示客户端和服务端组件版本：

--- a/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/dev/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -90,7 +90,7 @@ helm init
 {{< copyable "shell-regular" >}}
 
 ``` shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
 ```
 
 安装完成后，执行 `helm version` 会同时显示客户端和服务端组件版本：

--- a/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
+++ b/v3.0/tidb-in-kubernetes/get-started/deploy-tidb-from-kubernetes-minikube.md
@@ -91,7 +91,7 @@ helm init
 {{< copyable "shell-regular" >}}
 
 ``` shell
-helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -P -o 'v\d+\.\d+\.\d')
+helm init --upgrade --tiller-image registry.cn-hangzhou.aliyuncs.com/google_containers/tiller:$(helm version --client --short | grep -Eo 'v[0-9]\.[0-9]+\.[0-9]+')
 ```
 
 安装完成后，执行 `helm version` 会同时显示客户端和服务端组件版本：


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
This PR fixes a grep command error which will appear on macOS.
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/docs/pull/1582
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, v3.0
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v2.1" indicates the documentation of TiDB 3.0/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->