### PR TITLE
TiDB 3.0 does not support the old Binlog

### DIFF
--- a/dev/how-to/upgrade/from-previous-version.md
+++ b/dev/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/dev/how-to/upgrade/to-tidb-3.0/']
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/dev/reference/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/dev/reference/tidb-binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容[TiDB Binlog Cluster 版本](/dev/reference/tidb-binlog/overview.md)。
 
 ## 升级兼容性说明
 

--- a/v2.1/how-to/upgrade/from-previous-version.md
+++ b/v2.1/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/v2.1/how-to/upgrade/to-tidb-3.0/']
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/v2.1/reference/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/v2.1/reference/tidb-binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容[TiDB Binlog Cluster 版本](/v2.1/reference/tidb-binlog/overview.md)。
 
 ## 升级兼容性说明
 

--- a/v3.0/how-to/upgrade/from-previous-version.md
+++ b/v3.0/how-to/upgrade/from-previous-version.md
@@ -6,7 +6,7 @@ aliases: ['/docs-cn/op-guide/tidb-v3.0-upgrade-guide/','/docs-cn/v3.0/how-to/upg
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/v3.0/reference/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/v3.0/reference/tidb-binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容[TiDB Binlog Cluster 版本](/v3.0/reference/tidb-binlog/overview.md)。
 
 ## 升级兼容性说明
 

--- a/v3.1/how-to/upgrade/from-previous-version.md
+++ b/v3.1/how-to/upgrade/from-previous-version.md
@@ -5,7 +5,7 @@ category: how-to
 
 # TiDB 3.0 升级操作指南
 
-本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容 [Kafka 版本的 TiDB Binlog](/v3.1/reference/tidb-binlog/tidb-binlog-kafka.md) 以及[TiDB Binlog Cluster 版本](/v3.1/reference/tidb-binlog/overview.md)。
+本文档适用于从 TiDB 2.0 版本（v2.0.1 及之后版本）或 TiDB 2.1 RC 版本升级到 TiDB 3.0 版本。TiDB 3.0 版本兼容[TiDB Binlog Cluster 版本](/v3.1/reference/tidb-binlog/overview.md)。
 
 ## 升级兼容性说明
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->

Remove the part that claimed TiDB 3.0 is compatible with the Kafka version of Binlog.