### PR TITLE
reference/tools: add "-tidb-password" cli flag in tidb-lightning config

### DIFF
--- a/dev/reference/tools/tidb-lightning/config.md
+++ b/dev/reference/tools/tidb-lightning/config.md
@@ -277,6 +277,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB Server 的端口（默认为 4000） | `tidb.port` |
 | --tidb-status *port* | TiDB Server 的状态端口的（默认为 10080） | `tidb.status-port` |
 | --tidb-user *user* | 连接到 TiDB 的用户名 | `tidb.user` |
+| --tidb-password *password* | 连接到 TiDB 的密码 | `tidb.password` |
 
 如果同时对命令行参数和配置文件中的对应参数进行更改，命令行参数将优先生效。例如，在 `cfg.toml` 文件中，不管对日志等级做出什么修改，运行 `./tidb-lightning -L debug --config cfg.toml` 命令总是将日志级别设置为 “debug”。
 

--- a/v2.1/reference/tools/tidb-lightning/config.md
+++ b/v2.1/reference/tools/tidb-lightning/config.md
@@ -277,6 +277,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB Server 的端口（默认为 4000） | `tidb.port` |
 | --tidb-status *port* | TiDB Server 的状态端口的（默认为 10080） | `tidb.status-port` |
 | --tidb-user *user* | 连接到 TiDB 的用户名 | `tidb.user` |
+| --tidb-password *password* | 连接到 TiDB 的密码 | `tidb.password` |
 
 如果同时对命令行参数和配置文件中的对应参数进行更改，命令行参数将优先生效。例如，在 `cfg.toml` 文件中，不管对日志等级做出什么修改，运行 `./tidb-lightning -L debug --config cfg.toml` 命令总是将日志级别设置为 “debug”。
 

--- a/v3.0/reference/tools/tidb-lightning/config.md
+++ b/v3.0/reference/tools/tidb-lightning/config.md
@@ -277,6 +277,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB Server 的端口（默认为 4000） | `tidb.port` |
 | --tidb-status *port* | TiDB Server 的状态端口的（默认为 10080） | `tidb.status-port` |
 | --tidb-user *user* | 连接到 TiDB 的用户名 | `tidb.user` |
+| --tidb-password *password* | 连接到 TiDB 的密码 | `tidb.password` |
 
 如果同时对命令行参数和配置文件中的对应参数进行更改，命令行参数将优先生效。例如，在 `cfg.toml` 文件中，不管对日志等级做出什么修改，运行 `./tidb-lightning -L debug --config cfg.toml` 命令总是将日志级别设置为 “debug”。
 

--- a/v3.1/reference/tools/tidb-lightning/config.md
+++ b/v3.1/reference/tools/tidb-lightning/config.md
@@ -277,6 +277,7 @@ min-available-ratio = 0.05
 | --tidb-port *port* | TiDB Server 的端口（默认为 4000） | `tidb.port` |
 | --tidb-status *port* | TiDB Server 的状态端口的（默认为 10080） | `tidb.status-port` |
 | --tidb-user *user* | 连接到 TiDB 的用户名 | `tidb.user` |
+| --tidb-password *password* | 连接到 TiDB 的密码 | `tidb.password` |
 
 如果同时对命令行参数和配置文件中的对应参数进行更改，命令行参数将优先生效。例如，在 `cfg.toml` 文件中，不管对日志等级做出什么修改，运行 `./tidb-lightning -L debug --config cfg.toml` 命令总是将日志级别设置为 “debug”。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this PR.-->

### What is changed, added or deleted? <!--Required-->
This PR adds a reference to -tidb-password command line flag for tidb-lightning in the config section.
<!--Tell us what you did and why.-->

### What is the related PR or file link(s)? <!--Write "N/A" or remove this item if it is not applicable-->
https://github.com/pingcap/docs/pull/1711
<!--Provide a reference link that is related to your change. For example, a link in the pingcap/docs repository. -->

### Which version does your change affect? <!--Required; write "N/A" if it is not applicable-->
dev, v2.1, v3.0 and v3.1
<!--Specify the version or versions that your change affect by adding a label at the right-hand side of this page. "dev" indicates the latest development version. "v3.0"/"v3.1"/"v2.1" indicates the documentation of TiDB 3.0/3.1-beta/2.1. If your change affects multiple versions, please update the documents for ALL the necessary versions.-->