### PR TITLE
dev/2.1/3.0/3.1/4.0: add global variable latency resulted by gvc.

### DIFF
--- a/dev/reference/configuration/tidb-server/mysql-variables.md
+++ b/dev/reference/configuration/tidb-server/mysql-variables.md
@@ -29,7 +29,7 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
   
 > **注意：**
 >
-> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置会持久化到存储层中，单个 TiDB 实例每 2 秒会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存，该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后，为了保证新会话的有效性，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 [Issue #14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/dev/reference/configuration/tidb-server/mysql-variables.md
+++ b/dev/reference/configuration/tidb-server/mysql-variables.md
@@ -26,6 +26,10 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
     ```sql
     SET @@global.autocommit = 1;
     ```
+  
+> **注意：**
+>
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/v2.1/reference/configuration/tidb-server/mysql-variables.md
+++ b/v2.1/reference/configuration/tidb-server/mysql-variables.md
@@ -22,7 +22,7 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
   
 > **注意：**
 >
-> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置会持久化到存储层中，单个 TiDB 实例每 2 秒会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存，该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后，为了保证新会话的有效性，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 [Issue #14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/v2.1/reference/configuration/tidb-server/mysql-variables.md
+++ b/v2.1/reference/configuration/tidb-server/mysql-variables.md
@@ -19,6 +19,10 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
     SET GLOBAL autocommit = 1;
     SET @@global.autocommit = 1;
     ```
+  
+> **注意：**
+>
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/v3.0/reference/configuration/tidb-server/mysql-variables.md
+++ b/v3.0/reference/configuration/tidb-server/mysql-variables.md
@@ -31,7 +31,7 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
 
 > **注意：**
 >
-> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置会持久化到存储层中，单个 TiDB 实例每 2 秒会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存，该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后，为了保证新会话的有效性，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 [Issue #14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/v3.0/reference/configuration/tidb-server/mysql-variables.md
+++ b/v3.0/reference/configuration/tidb-server/mysql-variables.md
@@ -29,6 +29,10 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
     SET @@global.autocommit = 1;
     ```
 
+> **注意：**
+>
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
+
 ### 会话范围值
 
 * 在变量名前加 `SESSION` 关键词或者是使用 `@@session.` 作为修饰符，或者是不加任何修饰符:

--- a/v3.1/reference/configuration/tidb-server/mysql-variables.md
+++ b/v3.1/reference/configuration/tidb-server/mysql-variables.md
@@ -30,7 +30,7 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
   
 > **注意：**
 >
-> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置会持久化到存储层中，单个 TiDB 实例每 2 秒会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存，该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后，为了保证新会话的有效性，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 [Issue #14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 

--- a/v3.1/reference/configuration/tidb-server/mysql-variables.md
+++ b/v3.1/reference/configuration/tidb-server/mysql-variables.md
@@ -27,6 +27,10 @@ MySQL 系统变量 (System Variables) 是一些系统参数，用于调整数据
     ```sql
     SET @@global.autocommit = 1;
     ```
+  
+> **注意：**
+>
+> 在分布式 TiDB 中，`GLOBAL` 变量的设置都会持久化到存储层中，单个 TiDB 实例每 2s 会主动进行一次全变量的获取并形成 `gvc` (global variables cache) 缓存, 该缓存有效时间最多可持续 2 秒。在设置 `GLOBAL` 变量之后为了保证新会话能够有效，请确保两个操作之间的间隔大于 2 秒。相关细节可以查看 Issue [#14531](https://github.com/pingcap/tidb/issues/14531)。
 
 ### 会话范围值
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### What is the related PR or file link(s)? <!--Required-->

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- [x] Reference link(s): Issue [#14531](https://github.com/pingcap/tidb/issues/14531)
- [ ] This PR is to align with:<!--Give links here-->
- [ ] N/A (not applicable)

### Which TiDB version(s) does your changes apply to? <!--Required-->

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [ ] All active versions: dev, v3.0, v2.1, v3.1
- [x] dev (the latest development version)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] All active and inactive versions
- [ ] N/A (not applicable)

**Note:** If your changes apply to multiple TiDB versions, make sure you update the documents in the **corresponding** version folders such as "dev", "v3.0", "v2.1" and "v3.1" in this PR.

- [ ] Updated one version first. Will update other versions after I get two LGTMs.
