### PR TITLE
sql: add doc of hex and binary expression support for `LOAD DATA`

### DIFF
--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -48,13 +48,12 @@ Query OK, 815264 rows affected (39.63 sec)
 Records: 815264  Deleted: 0  Skipped: 0  Warnings: 0
 ```
 
-`LOAD` `DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数
-
+`LOAD DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数
 ```sql
 LOAD DATA LOCAL INFILE '/mnt/evo970/data-sets/bikeshare-data/2017Q4-capitalbikeshare-tripdata.csv' INTO TABLE trips FIELDS TERMINATED BY x'2c' ENCLOSED BY b'100010' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);
 ```
 
-其中 `x'2c'` 是字符 `,` 的十六进制表示，`b'100010'` 是字符 `"` 的二进制表示
+以上示例中 `x'2c'` 是字符 `,` 的十六进制表示，`b'100010'` 是字符 `"` 的二进制表示
 
 ## MySQL 兼容性
 

--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -48,7 +48,7 @@ Query OK, 815264 rows affected (39.63 sec)
 Records: 815264  Deleted: 0  Skipped: 0  Warnings: 0
 ```
 
-`LOAD DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数
+`LOAD DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数。示例如下：
 
 {{< copyable "sql" >}}
 
@@ -56,7 +56,7 @@ Records: 815264  Deleted: 0  Skipped: 0  Warnings: 0
 LOAD DATA LOCAL INFILE '/mnt/evo970/data-sets/bikeshare-data/2017Q4-capitalbikeshare-tripdata.csv' INTO TABLE trips FIELDS TERMINATED BY x'2c' ENCLOSED BY b'100010' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);
 ```
 
-以上示例中 `x'2c'` 是字符 `,` 的十六进制表示，`b'100010'` 是字符 `"` 的二进制表示
+以上示例中 `x'2c'` 是字符 `,` 的十六进制表示，`b'100010'` 是字符 `"` 的二进制表示。
 
 ## MySQL 兼容性
 

--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -49,6 +49,9 @@ Records: 815264  Deleted: 0  Skipped: 0  Warnings: 0
 ```
 
 `LOAD DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数
+
+{{< copyable "sql" >}}
+
 ```sql
 LOAD DATA LOCAL INFILE '/mnt/evo970/data-sets/bikeshare-data/2017Q4-capitalbikeshare-tripdata.csv' INTO TABLE trips FIELDS TERMINATED BY x'2c' ENCLOSED BY b'100010' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);
 ```

--- a/dev/reference/sql/statements/load-data.md
+++ b/dev/reference/sql/statements/load-data.md
@@ -48,6 +48,14 @@ Query OK, 815264 rows affected (39.63 sec)
 Records: 815264  Deleted: 0  Skipped: 0  Warnings: 0
 ```
 
+`LOAD` `DATA` 也支持使用十六进制 ASCII 字符表达式或二进制 ASCII 字符表达式作为 `FIELDS ENCLOSED BY` 和 `FIELDS TERMINATED BY` 的参数
+
+```sql
+LOAD DATA LOCAL INFILE '/mnt/evo970/data-sets/bikeshare-data/2017Q4-capitalbikeshare-tripdata.csv' INTO TABLE trips FIELDS TERMINATED BY x'2c' ENCLOSED BY b'100010' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (duration, start_date, end_date, start_station_number, start_station, end_station_number, end_station, bike_number, member_type);
+```
+
+其中 `x'2c'` 是字符 `,` 的十六进制表示，`b'100010'` 是字符 `"` 的二进制表示
+
 ## MySQL 兼容性
 
 * 默认情况下，TiDB 每 20,000 行会进行一次提交。这类似于 MySQL NDB Cluster，但并非 InnoDB 存储引擎的默认配置。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? <!--Required-->
`LOAD DATA` has supported using hex or binary literal to represent ascii character for `ENCLOSED BY` and `TERMINATED BY` in 4.0

This pr add example for `LOAD DATA` doc

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### What is the related PR or file link(s)? <!--Required-->

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- [ ] Reference link(s):<!--Give links here-->
- [ ] This PR is to align with:<!--Give links here-->
- [x] N/A (not applicable)

### Which TiDB version(s) does your changes apply to? <!--Required-->

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [ ] All active versions: dev, v3.0, v2.1, v3.1
- [ ] dev (the latest development version)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] All active and inactive versions
- [ ] N/A (not applicable)

**Note:** If your changes apply to multiple TiDB versions, make sure you update the documents in the **corresponding** version folders such as "dev", "v3.0", "v2.1" and "v3.1" in this PR.

- [ ] Updated one version first. Will update other versions after I get two LGTMs.
