### PR TITLE
reference: change default value for two tidb-specific variables

### DIFF
--- a/reference/configuration/tidb-server/tidb-specific-variables.md
+++ b/reference/configuration/tidb-server/tidb-specific-variables.md
@@ -361,7 +361,7 @@ set @@global.tidb_distsql_scan_concurrency = 10;
 
 作用域：GLOBAL
 
-默认值：16
+默认值：4
 
 这个变量用来设置 DDL 操作 re-organize 阶段的并发度。
 
@@ -369,7 +369,7 @@ set @@global.tidb_distsql_scan_concurrency = 10;
 
 作用域：GLOBAL
 
-默认值：1024
+默认值：256
 
 这个变量用来设置 DDL 操作 re-organize 阶段的 batch size。比如 Add Index 操作，需要回填索引数据，通过并发 tidb_ddl_reorg_worker_cnt 个 worker 一起回填数据，每个 worker 以 batch 为单位进行回填。如果 Add Index 时有较多 Update 操作或者 Replace 等更新操作，batch size 越大，事务冲突的概率也会越大，此时建议调小 batch size 的值，最小值是 32。在没有事务冲突的情况下，batch size 可设为较大值，最大值是 10240，这样回填数据的速度更快，但是 TiKV 的写入压力也会变大。
 


### PR DESCRIPTION
…b_ddl_reorg_batch_size

<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

change `tidb_ddl_reorg_worker_cnt` default value from 16 to 4
change `tidb_ddl_reorg_batch_size` default value from 1024 to 256

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version, including v4.0 changes for now)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here--> https://github.com/pingcap/docs/pull/1971
- Other reference link(s):<!--Give links here-->
