### PR TITLE
reference/configuration: correct a spelling mistake

### DIFF
--- a/reference/configuration/tikv-server/configuration-file.md
+++ b/reference/configuration/tikv-server/configuration-file.md
@@ -93,7 +93,7 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 
 读取线程池相关的配置项。
 
-### `unify-thread-pool`
+### `unify-read-pool`
 
 + 是否使用单个线程池处理所有的读请求。
 + 默认值：true


### PR DESCRIPTION
# What is changed, added or deleted? (Required)

Correct spelling mistakes:unify-thread-pool -> unify-read-pool.

### Which TiDB version(s) do your changes apply to? (Required)
- [x] master (the latest development version, including v4.0 changes for now)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)



### What is the related PR or file link(s)?


