### PR TITLE
sql: remove `repair` in admin doc

### DIFF
--- a/reference/sql/statements/admin.md
+++ b/reference/sql/statements/admin.md
@@ -47,14 +47,6 @@ ADMIN CHECK TABLE tbl_name [, tbl_name] ...;
 
 `ADMIN CHECK TABLE` 用于对表 `tbl_name` 中的所有数据和对应索引进行一致性校验。若通过校验，则返回空的查询结果；否则返回数据不一致的错误信息。
 
-{{< copyable "sql" >}}
-
-```sql
-ADMIN REPAIR TABLE tbl_name CREATE TABLE STATEMENT;
-```
-
-`ADMIN REPAIR TABLE` 用于在极端情况下，对存储层中的表的元信息进行非可信的覆盖。“非可信”是指需要人为保证原表的元信息可以完全由 `CREATE TABLE STATEMENT` 提供。该语句需要打开配置文件项中的 [`repair-mode`](/reference/configuration/tidb-server/configuration-file.md#repair-mode) 开关，并且需要确保所修复的表名在 [`repair-table-list`](/reference/configuration/tidb-server/configuration-file.md#repair-table-list) 名单中。
-
 ## 语句概览
 
 **AdminStmt**：


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)

remove `ADMIN REPAIR TABLE tbl_name`

### Which TiDB version(s) do your changes apply to? (Required)

<!--Tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [ ] master (the latest development version, including v4.0 changes for now)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

**If you select two or more versions from above**, to trigger the bot to cherry-pick this PR to your desired release version branch(es), you **must** add corresponding labels such as **needs-cherry-pick-3.1**, **needs-cherry-pick-3.0**, and **needs-cherry-pick-2.1**.

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here-->
- Other reference link(s): https://github.com/pingcap/docs-cn/pull/2504, https://github.com/pingcap/docs-cn/pull/2571
