### PR TITLE
docs-cn: Modify default value in  topology example 

### DIFF
--- a/how-to/deploy/orchestrated/tiup.md
+++ b/how-to/deploy/orchestrated/tiup.md
@@ -377,8 +377,8 @@ server_configs:
     readpool.coprocessor.use-unified-pool: true
   pd:
     schedule.leader-schedule-limit: 4
-    schedule.region-schedule-limit: 2048
-    schedule.replica-schedule-limit: 64
+    schedule.region-schedule-limit: 4
+    schedule.replica-schedule-limit: 8
     replication.enable-placement-rules: true
   tiflash:
     logger.level: "info"
@@ -1314,8 +1314,8 @@ tidb_servers:
       readpool.coprocessor.use-unified-pool: true
     pd:
       schedule.leader-schedule-limit: 4
-      schedule.region-schedule-limit: 2048
-      schedule.replica-schedule-limit: 64
+      schedule.region-schedule-limit: 4
+      schedule.replica-schedule-limit: 8
       replication.enable-placement-rules: true
     pump:
         gc: 7


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. See [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) before filing this pull request (PR).-->

### What is changed, added or deleted? (Required)
The default value of region-schedule-limit is 4.
The default value of replica-schedule-limit is 8.
The example file will confuse users.

<!--Tell us what you did and why. This is important to help reviewers and community members understand your PR.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] (that is, [x]) or tick the checkbox(es) below to choose the TiDB version(s) that your changes apply to.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with write access in the docs-cn repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add corresponding labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", and "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR, for example, a file link that supports why you changed the document.-->

- This PR is translated from:<!--Give links here-->
- Other reference link(s):<!--Give links here-->
