### PR TITLE
github action: add PTAL label for release-xxx PRs

### DIFF
--- a/.github/auto-label.json
+++ b/.github/auto-label.json
@@ -1,6 +1,5 @@
 {
   "rules": {
-    "translation/welcome": ["*.md", "*.yml", "*.yaml", "*.json", "media/", "scripts/"],
     "status/PTAL": ["*.md", "*.yml", "*.yaml", "*.json", "media/", "scripts/"]
   }
 }

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -2,7 +2,7 @@ name: Auto Label
 on:
   pull_request:
     branches:
-      - master
+      - 'release-*'
     types: [opened]
 
 jobs:


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
