### PR TITLE
add auto assign reviewer github action

### DIFF
--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -34,8 +34,5 @@
 
 # Changing all md files should request a language review in case of format failures.
 # TomShawn is the repo administrator.
-'*.md':
-  - TomShawn
-
-'media/':
+'*.*':
   - TomShawn

--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,0 +1,41 @@
+---
+# you can use glob pattern
+
+# Changing all md files should request a language review in case of format failures.
+# TomShawn is the repo administrator.
+'*.md':
+  - TomShawn
+
+'media/':
+  - TomShawn
+
+# You can set multiple reviewers
+'.github/':
+  - yikeke
+  - ran-huang
+
+'tiflash/':
+  - zanmato1984
+  - kissmydb
+  - yikeke
+
+'tiup/':
+  - lonng
+  - lucklove
+  - kissmydb
+  - yikeke
+
+'sql-statements/':
+  - bb7133
+
+'releases/':
+  - scsldb
+
+'dashboard/':
+  - breeswish
+
+'config-templates/':
+  - kissmydb
+
+'ticdc/':
+  - WangXiangUSTC

--- a/.github/assign-by-files.yml
+++ b/.github/assign-by-files.yml
@@ -1,6 +1,37 @@
 ---
 # you can use glob pattern
 
+# You can set multiple reviewers
+# '.github/':
+#   - yikeke
+#   - ran-huang
+
+# 'tiflash/':
+#   - zanmato1984
+#   - kissmydb
+#   - yikeke
+
+# 'tiup/':
+#   - lonng
+#   - lucklove
+#   - kissmydb
+#   - yikeke
+
+# 'sql-statements/':
+#   - bb7133
+
+# 'releases/':
+#   - scsldb
+
+# 'dashboard/':
+#   - breeswish
+
+# 'config-templates/':
+#   - kissmydb
+
+# 'ticdc/':
+#   - WangXiangUSTC
+
 # Changing all md files should request a language review in case of format failures.
 # TomShawn is the repo administrator.
 '*.md':
@@ -8,34 +39,3 @@
 
 'media/':
   - TomShawn
-
-# You can set multiple reviewers
-'.github/':
-  - yikeke
-  - ran-huang
-
-'tiflash/':
-  - zanmato1984
-  - kissmydb
-  - yikeke
-
-'tiup/':
-  - lonng
-  - lucklove
-  - kissmydb
-  - yikeke
-
-'sql-statements/':
-  - bb7133
-
-'releases/':
-  - scsldb
-
-'dashboard/':
-  - breeswish
-
-'config-templates/':
-  - kissmydb
-
-'ticdc/':
-  - WangXiangUSTC

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-    types: [opened]
+    types: [opened, labeled]
 
 jobs:
   assign_reviewer:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
     branches:
       - master
-    types: [opened, labeled]
+    types: [opened]
 
 jobs:
   assign_reviewer:

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,15 @@
+name: "Auto Assign"
+on:
+  pull_request:
+    branches:
+      - master
+    types: [opened]
+
+jobs:
+  assign_reviewer:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: shufo/auto-assign-reviewer-by-files@v1.0.0
+      with:
+        config: '.github/assign-by-files.yml'
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

makes TomShawn the default reviewer for all prs in docs-cn repo
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
 add github action https://github.com/marketplace/actions/auto-assign-reviewer-by-files