### PR TITLE
Delete `push` related command-line flags

### DIFF
--- a/command-line-flags-for-pd-configuration.md
+++ b/command-line-flags-for-pd-configuration.md
@@ -98,12 +98,6 @@ PD 可以通过命令行参数或环境变量配置。
 + 包含 X509 key 的 PEM 文件路径，用于开启 TLS。
 + 默认：""
 
-## `--metrics-addr`
-
-+ 指定 Prometheus Pushgateway 的地址。
-+ 默认：""
-+ 如果留空，则不开启 Prometheus Push。
-
 ## `--force-new-cluster`
 
 + 强制使用当前节点创建新的集群。


### PR DESCRIPTION
Pushgateway 已经从监控提供中剔除，此类 metric 已经无用，请评估，

其他类似

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
