### PR TITLE
Add aliases for 3.0 sysbench docs

### DIFF
--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Sysbench 性能对比测试报告 - v3.0 对比 v2.1
 category: benchmark
-aliases: ['/docs-cn/v3.0/benchmark/sysbench-v4/','/docs-cn/benchmark/sysbench-v4/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs-cn/stable/benchmark/sysbench-v4/','/zh/tidb/v4.0/v3.0-performance-benchmarking-with-sysbench']
+aliases: ['/docs-cn/v3.0/benchmark/sysbench-v4/','/docs-cn/benchmark/sysbench-v4/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs-cn/v4.0/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs-cn/stable/benchmark/sysbench-v4/','/zh/tidb/v4.0/v3.0-performance-benchmarking-with-sysbench']
 ---
 
 # TiDB Sysbench 性能对比测试报告 - v3.0 对比 v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v3.0-performance-benchmarking-with-sysbench.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Sysbench 性能对比测试报告 - v3.0 对比 v2.1
 category: benchmark
-aliases: ['/docs-cn/v3.0/benchmark/sysbench-v4/','/docs-cn/benchmark/sysbench-v4/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/']
+aliases: ['/docs-cn/v3.0/benchmark/sysbench-v4/','/docs-cn/benchmark/sysbench-v4/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-sysbench/','/docs-cn/stable/benchmark/sysbench-v4/','/zh/tidb/v4.0/v3.0-performance-benchmarking-with-sysbench']
 ---
 
 # TiDB Sysbench 性能对比测试报告 - v3.0 对比 v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v3.0-performance-benchmarking-with-tpcc.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB TPC-C 性能对比测试报告 - v3.0 对比 v2.1
 category: benchmark
-aliases: ['/docs-cn/v3.0/benchmark/tpcc/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-tpcc/']
+aliases: ['/docs-cn/v3.0/benchmark/tpcc/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs-cn/stable/benchmark/tpcc/','/zh/tidb/v4.0/v4.0-performance-benchmarking-with-tpcc']
 ---
 
 # TiDB TPC-C 性能对比测试报告 - v3.0 对比 v2.1

--- a/benchmark/v3.0-performance-benchmarking-with-tpcc.md
+++ b/benchmark/v3.0-performance-benchmarking-with-tpcc.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB TPC-C 性能对比测试报告 - v3.0 对比 v2.1
 category: benchmark
-aliases: ['/docs-cn/v3.0/benchmark/tpcc/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs-cn/stable/benchmark/tpcc/','/zh/tidb/v4.0/v4.0-performance-benchmarking-with-tpcc']
+aliases: ['/docs-cn/v3.0/benchmark/tpcc/','/docs-cn/stable/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs-cn/v4.0/benchmark/v3.0-performance-benchmarking-with-tpcc/','/docs-cn/stable/benchmark/tpcc/','/zh/tidb/v4.0/v3.0-performance-benchmarking-with-tpcc']
 ---
 
 # TiDB TPC-C 性能对比测试报告 - v3.0 对比 v2.1


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Add aliases for `benchmark/v3.0-performance-benchmarking-with-sysbench.md` and `benchmark/v3.0-performance-benchmarking-with-tpcc.md` deleted in `release-4.0` branch.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/3182
- Other reference link(s): https://github.com/pingcap/docs-cn/pull/3904
