### PR TITLE
perf-tuning: update anchors in wrong-index-solution

### DIFF
--- a/wrong-index-solution.md
+++ b/wrong-index-solution.md
@@ -16,9 +16,9 @@ category: performance
 
 这时意味着刚刚结束 `ANALYZE` 命令或者结束后不久。这时可能和 TiDB 对行数的估算逻辑有关。
 
-对于等值查询，在[统计信息简介](/statistics.md)中提到了一种可能的情况。这时可以先检查是不是这种特殊情况，然后进行对应的处理。
+对于等值查询，错误索引可能是由 [Count-Min Sketch](/statistics.md#count-min-sketch) 引起的。这时可以先检查是不是这种特殊情况，然后进行对应的处理。
 
-如果经过检查发现不是上面的可能情况，可以使用 [Optimizer Hints](/optimizer-hints.md) 中提到的 `USE_INDEX` 或者 `use index` 来强制选择索引。同时也可以使用[执行计划管理](/sql-plan-management.md)中提到的方式来非侵入地更改查询的行为。
+如果经过检查发现不是上面的可能情况，可以使用 [Optimizer Hints](/optimizer-hints.md##use_indext1_name-idx1_name--idx2_name-) 中提到的 `USE_INDEX` 或者 `use index` 来强制选择索引。同时也可以使用[执行计划管理](/sql-plan-management.md)中提到的方式来非侵入地更改查询的行为。
 
 ## 其他情况
 

--- a/wrong-index-solution.md
+++ b/wrong-index-solution.md
@@ -18,7 +18,7 @@ category: performance
 
 对于等值查询，错误索引可能是由 [Count-Min Sketch](/statistics.md#count-min-sketch) 引起的。这时可以先检查是不是这种特殊情况，然后进行对应的处理。
 
-如果经过检查发现不是上面的可能情况，可以使用 [Optimizer Hints](/optimizer-hints.md##use_indext1_name-idx1_name--idx2_name-) 中提到的 `USE_INDEX` 或者 `use index` 来强制选择索引。同时也可以使用[执行计划管理](/sql-plan-management.md)中提到的方式来非侵入地更改查询的行为。
+如果经过检查发现不是上面的可能情况，可以使用 [Optimizer Hints](/optimizer-hints.md#use_indext1_name-idx1_name--idx2_name-) 中提到的 `USE_INDEX` 或者 `use index` 来强制选择索引。同时也可以使用[执行计划管理](/sql-plan-management.md)中提到的方式来非侵入地更改查询的行为。
 
 ## 其他情况
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
Refine some anchors to make the content more readable.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
