### PR TITLE
v2.1: remove `category` meta

### DIFF
--- a/_index.md
+++ b/_index.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 简介
-category: introduction
 ---
 
 # TiDB 简介

--- a/alert-rules.md
+++ b/alert-rules.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 集群报警规则
 summary: TiDB 集群中各组件的报警规则详解。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/alert-rules/']
 ---
 

--- a/architecture.md
+++ b/architecture.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 整体架构
-category: introduction
 ---
 
 # TiDB 整体架构

--- a/backup-and-restore.md
+++ b/backup-and-restore.md
@@ -1,6 +1,5 @@
 ---
 title: 备份与恢复
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/maintain/backup-and-restore/']
 ---
 

--- a/basic-sql-operations.md
+++ b/basic-sql-operations.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 中的基本 SQL 操作
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/explore-sql/']
 ---
 

--- a/benchmark/benchmark-tidb-using-sysbench.md
+++ b/benchmark/benchmark-tidb-using-sysbench.md
@@ -1,6 +1,5 @@
 ---
 title: 如何用 Sysbench 测试 TiDB
-category: benchmark
 aliases: ['/docs-cn/v2.1/benchmark/how-to-run-sysbench/']
 ---
 

--- a/benchmark/v2.1-performance-benchmarking-with-sysbench.md
+++ b/benchmark/v2.1-performance-benchmarking-with-sysbench.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Sysbench 性能对比测试报告 - v2.1 对比 v2.0
-category: benchmark
 aliases: ['/docs-cn/v2.1/benchmark/sysbench-v3/']
 ---
 

--- a/benchmark/v2.1-performance-benchmarking-with-tpch.md
+++ b/benchmark/v2.1-performance-benchmarking-with-tpch.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB TPC-H 50G 性能测试报告
-category: benchmark
 aliases: ['/docs-cn/v2.1/benchmark/tpch-v2/']
 ---
 

--- a/best-practices/grafana-monitor-best-practices.md
+++ b/best-practices/grafana-monitor-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: 使用 Grafana 监控 TiDB 的最佳实践
 summary: 了解高效利用 Grafana 监控 TiDB 的七个技巧。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/best-practices/grafana-monitor/']
 ---
 

--- a/best-practices/haproxy-best-practices.md
+++ b/best-practices/haproxy-best-practices.md
@@ -1,6 +1,5 @@
 ---
 title: HAProxy 在 TiDB 中的最佳实践
-category: reference
 aliases: ['/docs-cn/v2.1/reference/best-practices/haproxy/']
 ---
 

--- a/best-practices/java-app-best-practices.md
+++ b/best-practices/java-app-best-practices.md
@@ -1,6 +1,5 @@
 ---
 title: 开发 Java 应用使用 TiDB 的最佳实践
-category: reference
 aliases: ['/docs-cn/v2.1/reference/best-practices/java-app/','/docs-cn/v2.1/reference/best-practices/using-tidb-in-java/']
 ---
 

--- a/best-practices/massive-regions-best-practices.md
+++ b/best-practices/massive-regions-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: 海量 Region 集群调优最佳实践
 summary: 了解海量 Region 导致性能问题的原因和优化方法。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/best-practices/massive-regions/']
 ---
 

--- a/best-practices/pd-scheduling-best-practices.md
+++ b/best-practices/pd-scheduling-best-practices.md
@@ -1,7 +1,6 @@
 ---
 title: PD 调度策略最佳实践
 summary: 了解 PD 调度策略的最佳实践和调优方式
-category: reference
 aliases: ['/docs-cn/v2.1/reference/best-practices/pd-scheduling/']
 ---
 

--- a/character-set-and-collation.md
+++ b/character-set-and-collation.md
@@ -1,6 +1,5 @@
 ---
 title: 字符集支持
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/character-set/']
 ---
 

--- a/column-pruning.md
+++ b/column-pruning.md
@@ -1,6 +1,5 @@
 ---
 title: 列裁剪
-category: performance
 ---
 
 # 列裁剪

--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 配置参数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/tidb-server/configuration/']
 ---
 

--- a/comment-syntax.md
+++ b/comment-syntax.md
@@ -1,6 +1,5 @@
 ---
 title: 注释语法
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/comment-syntax/']
 ---
 

--- a/configure-memory-usage.md
+++ b/configure-memory-usage.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 内存控制文档
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/configure/memory-control/']
 ---
 

--- a/configure-time-zone.md
+++ b/configure-time-zone.md
@@ -1,6 +1,5 @@
 ---
 title: 时区支持
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/configure/time-zone/']
 ---
 

--- a/connectors-and-apis.md
+++ b/connectors-and-apis.md
@@ -1,6 +1,5 @@
 ---
 title: 连接器和 API
-category: reference
 aliases: ['/docs-cn/v2.1/reference/supported-clients/']
 ---
 

--- a/constraints.md
+++ b/constraints.md
@@ -1,6 +1,5 @@
 ---
 title: 约束
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/constraints/']
 ---
 

--- a/contribute.md
+++ b/contribute.md
@@ -1,6 +1,5 @@
 ---
 title: 成为贡献者
-category: contribute
 ---
 
 # 成为贡献者

--- a/data-type-date-and-time.md
+++ b/data-type-date-and-time.md
@@ -1,6 +1,5 @@
 ---
 title: 日期和时间类型
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/date-and-time/']
 ---
 

--- a/data-type-default-values.md
+++ b/data-type-default-values.md
@@ -1,6 +1,5 @@
 ---
 title: 数据类型的默认值
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/default-values/']
 ---
 

--- a/data-type-json.md
+++ b/data-type-json.md
@@ -1,6 +1,5 @@
 ---
 title: JSON 类型
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/json/']
 ---
 

--- a/data-type-numeric.md
+++ b/data-type-numeric.md
@@ -1,6 +1,5 @@
 ---
 title: 数值类型
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/numeric/']
 ---
 

--- a/data-type-overview.md
+++ b/data-type-overview.md
@@ -1,6 +1,5 @@
 ---
 title: 数据类型概述
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/overview/']
 ---
 

--- a/data-type-string.md
+++ b/data-type-string.md
@@ -1,6 +1,5 @@
 ---
 title: 字符串类型
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/data-types/string/']
 ---
 

--- a/deploy-test-cluster-using-docker-compose.md
+++ b/deploy-test-cluster-using-docker-compose.md
@@ -1,6 +1,5 @@
 ---
 title: 使用 Docker Compose 快速构建 TiDB 集群
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/deploy-tidb-from-docker-compose/','/docs-cn/v2.1/how-to/get-started/local-cluster/install-from-docker-compose/']
 ---
 

--- a/download-ecosystem-tools.md
+++ b/download-ecosystem-tools.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 工具下载
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/download/']
 ---
 

--- a/ecosystem-tool-user-case.md
+++ b/ecosystem-tool-user-case.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 生态工具适用场景
-category: reference
 summary: 本文档介绍 TiDB 生态工具的常见适用场景与工具选择。
 ---
 

--- a/ecosystem-tool-user-guide.md
+++ b/ecosystem-tool-user-guide.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 生态工具功能概览
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/user-guide/','/docs-cn/v2.1/how-to/migrate/from-mysql/', '/docs-cn/v2.1/how-to/migrate/incrementally-from-mysql/', '/docs-cn/v2.1/how-to/migrate/overview/', '/docs-cn/v2.1/reference/tools/use-guide/']
 ---
 

--- a/enable-tls-between-components.md
+++ b/enable-tls-between-components.md
@@ -1,6 +1,5 @@
 ---
 title: 为 TiDB 组件间开启 TLS 和数据加密存储
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/secure/enable-tls-between-components/']
 ---
 

--- a/encrypted-connections-with-tls-protocols.md
+++ b/encrypted-connections-with-tls-protocols.md
@@ -1,6 +1,5 @@
 ---
 title: 使用加密连接
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/secure/enable-tls-clients/']
 ---
 

--- a/error-codes.md
+++ b/error-codes.md
@@ -1,6 +1,5 @@
 ---
 title: 错误码与故障诊断
-category: reference
 aliases: ['/docs-cn/v2.1/reference/error-codes/']
 ---
 

--- a/export-or-backup-using-dumpling.md
+++ b/export-or-backup-using-dumpling.md
@@ -1,7 +1,6 @@
 ---
 title: 使用 Dumpling 导出或备份 TiDB 数据
 summary: 使用新的导出工具 Dumpling 导出或者备份数据。
-category: how-to
 ---
 
 # 使用 Dumpling 导出或备份 TiDB 数据

--- a/expression-syntax.md
+++ b/expression-syntax.md
@@ -1,6 +1,5 @@
 ---
 title: 表达式语法
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/expression-syntax/']
 ---
 

--- a/faq/tidb-faq.md
+++ b/faq/tidb-faq.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB FAQ
-category: FAQ
 aliases: ['/docs-cn/v2.1/faq/tidb/']
 ---
 

--- a/faq/upgrade-faq.md
+++ b/faq/upgrade-faq.md
@@ -1,6 +1,5 @@
 ---
 title: 升级后常见问题
-category: FAQ
 aliases: ['/docs-cn/v2.1/faq/upgrade/']
 ---
 

--- a/functions-and-operators/aggregate-group-by-functions.md
+++ b/functions-and-operators/aggregate-group-by-functions.md
@@ -1,6 +1,5 @@
 ---
 title: GROUP BY 聚合函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/aggregate-group-by-functions/']
 ---
 

--- a/functions-and-operators/bit-functions-and-operators.md
+++ b/functions-and-operators/bit-functions-and-operators.md
@@ -1,6 +1,5 @@
 ---
 title: 位函数和操作符
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/bit-functions-and-operators/']
 ---
 

--- a/functions-and-operators/cast-functions-and-operators.md
+++ b/functions-and-operators/cast-functions-and-operators.md
@@ -1,6 +1,5 @@
 ---
 title: Cast 函数和操作符
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/cast-functions-and-operators/']
 ---
 

--- a/functions-and-operators/control-flow-functions.md
+++ b/functions-and-operators/control-flow-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 控制流程函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/control-flow-functions/']
 ---
 

--- a/functions-and-operators/date-and-time-functions.md
+++ b/functions-and-operators/date-and-time-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 日期和时间函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/date-and-time-functions/']
 ---
 

--- a/functions-and-operators/encryption-and-compression-functions.md
+++ b/functions-and-operators/encryption-and-compression-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 加密和压缩函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/encryption-and-compression-functions/']
 ---
 

--- a/functions-and-operators/functions-and-operators-overview.md
+++ b/functions-and-operators/functions-and-operators-overview.md
@@ -1,6 +1,5 @@
 ---
 title: 函数和操作符概述
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/reference/']
 ---
 

--- a/functions-and-operators/information-functions.md
+++ b/functions-and-operators/information-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 信息函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/information-functions/']
 ---
 

--- a/functions-and-operators/json-functions.md
+++ b/functions-and-operators/json-functions.md
@@ -1,6 +1,5 @@
 ---
 title: JSON 函数及语法糖
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/json-functions/']
 ---
 

--- a/functions-and-operators/miscellaneous-functions.md
+++ b/functions-and-operators/miscellaneous-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 其他函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/miscellaneous-functions/']
 ---
 

--- a/functions-and-operators/numeric-functions-and-operators.md
+++ b/functions-and-operators/numeric-functions-and-operators.md
@@ -1,6 +1,5 @@
 ---
 title: 数值函数与操作符
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/numeric-functions-and-operators/']
 ---
 

--- a/functions-and-operators/operators.md
+++ b/functions-and-operators/operators.md
@@ -1,6 +1,5 @@
 ---
 title: 操作符
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/operators/']
 ---
 

--- a/functions-and-operators/precision-math.md
+++ b/functions-and-operators/precision-math.md
@@ -1,6 +1,5 @@
 ---
 title: 精度数学
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/precision-math/']
 ---
 

--- a/functions-and-operators/string-functions.md
+++ b/functions-and-operators/string-functions.md
@@ -1,6 +1,5 @@
 ---
 title: 字符串函数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/string-functions/']
 ---
 

--- a/functions-and-operators/type-conversion-in-expression-evaluation.md
+++ b/functions-and-operators/type-conversion-in-expression-evaluation.md
@@ -1,6 +1,5 @@
 ---
 title: 表达式求值的类型转换
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/functions-and-operators/type-conversion/']
 ---
 

--- a/garbage-collection.md
+++ b/garbage-collection.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 垃圾回收 (GC)
-category: reference
 aliases: ['/docs-cn/v2.1/reference/garbage-collection/']
 ---
 

--- a/generate-self-signed-certificates.md
+++ b/generate-self-signed-certificates.md
@@ -1,6 +1,5 @@
 ---
 title: 生成自签名证书
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/secure/generate-self-signed-certificates/']
 ---
 

--- a/generated-columns.md
+++ b/generated-columns.md
@@ -1,6 +1,5 @@
 ---
 title: 生成列
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/generated-columns/']
 ---
 

--- a/geo-redundancy-deployment.md
+++ b/geo-redundancy-deployment.md
@@ -1,6 +1,5 @@
 ---
 title: 跨数据中心部署方案
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/geographic-redundancy/overview/']
 ---
 

--- a/get-started-with-tidb-binlog.md
+++ b/get-started-with-tidb-binlog.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 教程
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/tidb-binlog/']
 ---
 

--- a/get-started-with-tidb-lightning.md
+++ b/get-started-with-tidb-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 教程
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/tidb-lightning/']
 ---
 

--- a/get-started-with-tispark.md
+++ b/get-started-with-tispark.md
@@ -1,6 +1,5 @@
 ---
 title: TiSpark 快速入门指南
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/tispark/']
 ---
 

--- a/glossary.md
+++ b/glossary.md
@@ -1,7 +1,6 @@
 ---
 title: 术语表
 summary: 了解 TiDB 相关术语。
-category: glossary
 ---
 
 # 术语表

--- a/grafana-overview-dashboard.md
+++ b/grafana-overview-dashboard.md
@@ -1,6 +1,5 @@
 ---
 title: Overview 面板重要监控指标详解
-category: reference
 aliases: ['/docs-cn/v2.1/reference/key-monitoring-metrics/overview-dashboard/']
 ---
 

--- a/grafana-pd-dashboard.md
+++ b/grafana-pd-dashboard.md
@@ -1,6 +1,5 @@
 ---
 title: PD 重要监控指标详解
-category: reference
 aliases: ['/docs-cn/v2.1/reference/key-monitoring-metrics/pd-dashboard/']
 ---
 

--- a/grafana-tidb-dashboard.md
+++ b/grafana-tidb-dashboard.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 重要监控指标详解
-category: reference
 aliases: ['/docs-cn/v2.1/reference/key-monitoring-metrics/tidb-dashboard/']
 ---
 

--- a/grafana-tikv-dashboard.md
+++ b/grafana-tikv-dashboard.md
@@ -1,6 +1,5 @@
 ---
 title: TiKV 重要监控指标详解
-category: reference
 aliases: ['/docs-cn/v2.1/reference/key-monitoring-metrics/tikv-dashboard/']
 ---
 

--- a/hardware-and-software-requirements.md
+++ b/hardware-and-software-requirements.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 软件和硬件环境建议配置
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/hardware-recommendations/']
 ---
 

--- a/identify-slow-queries.md
+++ b/identify-slow-queries.md
@@ -1,6 +1,5 @@
 ---
 title: 慢查询日志
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/maintain/identify-slow-queries/','/docs-cn/sql/slow-query/']
 ---
 

--- a/key-features.md
+++ b/key-features.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 核心特性
-category: introduction
 ---
 
 # TiDB 核心特性

--- a/keywords-and-reserved-words.md
+++ b/keywords-and-reserved-words.md
@@ -1,6 +1,5 @@
 ---
 title: 关键字和保留字
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/keywords-and-reserved-words/']
 ---
 

--- a/literal-values.md
+++ b/literal-values.md
@@ -1,6 +1,5 @@
 ---
 title: 字面值
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/literal-values/']
 ---
 

--- a/loader-overview.md
+++ b/loader-overview.md
@@ -1,6 +1,5 @@
 ---
 title: Loader 使用文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/loader/']
 ---
 

--- a/location-awareness.md
+++ b/location-awareness.md
@@ -1,6 +1,5 @@
 ---
 title: 集群拓扑信息配置
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/geographic-redundancy/location-awareness/']
 ---
 

--- a/maintain-tidb-using-ansible.md
+++ b/maintain-tidb-using-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Ansible 常见运维操作
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/maintain/ansible-operations/']
 ---
 

--- a/migrate-from-aurora-mysql-database.md
+++ b/migrate-from-aurora-mysql-database.md
@@ -1,7 +1,6 @@
 ---
 title: 从 MySQL 迁移数据 —— 以 Amazon Aurora MySQL 为例
 summary: 使用 DM 从 MySQL/Amazon Aurora MySQL 迁移数据。
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/migrate/from-aurora/']
 ---
 

--- a/migrate-from-mysql-mydumper-files.md
+++ b/migrate-from-mysql-mydumper-files.md
@@ -1,7 +1,6 @@
 ---
 title: 从 MySQL SQL 文件迁移数据
 summary: 使用 TiDB Lightning 从 MySQL 迁移数据。
-category: how-to
 ---
 
 # 从 MySQL SQL 文件迁移数据

--- a/migrate-full-data-from-mysql.md
+++ b/migrate-full-data-from-mysql.md
@@ -1,6 +1,5 @@
 ---
 title: 全量数据迁移
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/migrate/from-mysql/']
 ---
 

--- a/migrate-incremental-data-from-mysql.md
+++ b/migrate-incremental-data-from-mysql.md
@@ -1,6 +1,5 @@
 ---
 title: 增量数据复制
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/migrate/incrementally-from-mysql/']
 ---
 

--- a/migration-overview.md
+++ b/migration-overview.md
@@ -1,6 +1,5 @@
 ---
 title: 数据迁移概述
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/migrate/overview/']
 ---
 

--- a/monitor-a-tidb-cluster.md
+++ b/monitor-a-tidb-cluster.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 集群监控
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/monitor/monitor-a-cluster/']
 ---
 

--- a/mydumper-overview.md
+++ b/mydumper-overview.md
@@ -1,7 +1,6 @@
 ---
 title: Mydumper 使用文档
 summary: 使用 Mydumper 从 TiDB 导出数据。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/mydumper/']
 ---
 

--- a/mysql-compatibility.md
+++ b/mysql-compatibility.md
@@ -1,6 +1,5 @@
 ---
 title: 与 MySQL 兼容性对比
-category: reference
 aliases: ['/docs-cn/v2.1/reference/mysql-compatibility/']
 ---
 

--- a/offline-deployment-using-ansible.md
+++ b/offline-deployment-using-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: 离线 TiDB Ansible 部署方案
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/orchestrated/offline-ansible/']
 ---
 

--- a/online-deployment-using-ansible.md
+++ b/online-deployment-using-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: 使用 TiDB Ansible 部署 TiDB 集群
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/orchestrated/ansible/']
 ---
 

--- a/optimistic-transaction.md
+++ b/optimistic-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 乐观事务模型
 summary: 了解 TiDB 的乐观事务模型。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/transactions/transaction-optimistic/','/docs-cn/v2.1/reference/transactions/transaction-model/']
 ---
 

--- a/optimizer-hints.md
+++ b/optimizer-hints.md
@@ -1,6 +1,5 @@
 ---
 title: Optimizer Hints
-category: reference
 aliases: ['/docs-cn/v2.1/reference/performance/optimizer-hints/']
 ---
 

--- a/overview.md
+++ b/overview.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 简介
-category: introduction
 ---
 
 # TiDB 简介

--- a/pd-configuration-file.md
+++ b/pd-configuration-file.md
@@ -1,6 +1,5 @@
 ---
 title: PD 配置参数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/pd-server/configuration/']
 ---
 

--- a/pd-control.md
+++ b/pd-control.md
@@ -1,6 +1,5 @@
 ---
 title: PD Control 使用说明
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/pd-control/']
 ---
 

--- a/pd-recover.md
+++ b/pd-recover.md
@@ -1,6 +1,5 @@
 ---
 title: PD Recover 使用文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/pd-recover/']
 ---
 

--- a/privilege-management.md
+++ b/privilege-management.md
@@ -1,6 +1,5 @@
 ---
 title: 权限管理
-category: reference
 aliases: ['/docs-cn/v2.1/reference/security/privilege-system/']
 ---
 

--- a/query-execution-plan.md
+++ b/query-execution-plan.md
@@ -1,6 +1,5 @@
 ---
 title: 理解 TiDB 执行计划
-category: reference
 aliases: ['/docs-cn/v2.1/reference/performance/understanding-the-query-execution-plan/']
 ---
 

--- a/read-historical-data.md
+++ b/read-historical-data.md
@@ -1,6 +1,5 @@
 ---
 title: 读取历史数据
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/get-started/read-historical-data/']
 ---
 

--- a/releases/release-1.0-ga.md
+++ b/releases/release-1.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.0 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/ga/']
 ---
 

--- a/releases/release-1.1-alpha.md
+++ b/releases/release-1.1-alpha.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.1 Alpha Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/11alpha/']
 ---
 

--- a/releases/release-1.1-beta.md
+++ b/releases/release-1.1-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 1.1 Beta Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/11beta/']
 ---
 

--- a/releases/release-2.0-ga.md
+++ b/releases/release-2.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.0ga/']
 ---
 

--- a/releases/release-2.0-rc.1.md
+++ b/releases/release-2.0-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2rc1/']
 ---
 

--- a/releases/release-2.0-rc.3.md
+++ b/releases/release-2.0-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC3 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2rc3/']
 ---
 

--- a/releases/release-2.0-rc.4.md
+++ b/releases/release-2.0-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC4 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2rc4/']
 ---
 

--- a/releases/release-2.0-rc.5.md
+++ b/releases/release-2.0-rc.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0 RC5 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2rc5/']
 ---
 

--- a/releases/release-2.0.1.md
+++ b/releases/release-2.0.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.1 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/201/']
 ---
 

--- a/releases/release-2.0.10.md
+++ b/releases/release-2.0.10.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.10 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.0.10/']
 ---
 

--- a/releases/release-2.0.11.md
+++ b/releases/release-2.0.11.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.11 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.0.11/']
 ---
 

--- a/releases/release-2.0.2.md
+++ b/releases/release-2.0.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.2 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/202/']
 ---
 

--- a/releases/release-2.0.3.md
+++ b/releases/release-2.0.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.3 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/203/']
 ---
 

--- a/releases/release-2.0.4.md
+++ b/releases/release-2.0.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.4 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/204/']
 ---
 

--- a/releases/release-2.0.5.md
+++ b/releases/release-2.0.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.5 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/205/']
 ---
 

--- a/releases/release-2.0.6.md
+++ b/releases/release-2.0.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.6 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/206/']
 ---
 

--- a/releases/release-2.0.7.md
+++ b/releases/release-2.0.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.7 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/207/']
 ---
 

--- a/releases/release-2.0.8.md
+++ b/releases/release-2.0.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.8 release notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/208/']
 ---
 

--- a/releases/release-2.0.9.md
+++ b/releases/release-2.0.9.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.0.9 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/209/']
 ---
 

--- a/releases/release-2.1-beta.md
+++ b/releases/release-2.1-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 Beta Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21beta/']
 ---
 

--- a/releases/release-2.1-ga.md
+++ b/releases/release-2.1-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 GA Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1ga/']
 ---
 

--- a/releases/release-2.1-rc.1.md
+++ b/releases/release-2.1-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21rc1/']
 ---
 

--- a/releases/release-2.1-rc.2.md
+++ b/releases/release-2.1-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC2 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21rc2/']
 ---
 

--- a/releases/release-2.1-rc.3.md
+++ b/releases/release-2.1-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC3 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21rc3/']
 ---
 

--- a/releases/release-2.1-rc.4.md
+++ b/releases/release-2.1-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC4 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21rc4/']
 ---
 

--- a/releases/release-2.1-rc.5.md
+++ b/releases/release-2.1-rc.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 RC5 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/21rc5/']
 ---
 

--- a/releases/release-2.1.1.md
+++ b/releases/release-2.1.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.1/']
 ---
 

--- a/releases/release-2.1.10.md
+++ b/releases/release-2.1.10.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.10 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.10/']
 ---
 

--- a/releases/release-2.1.11.md
+++ b/releases/release-2.1.11.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.11 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.11/']
 ---
 

--- a/releases/release-2.1.12.md
+++ b/releases/release-2.1.12.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.12 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.12/']
 ---
 

--- a/releases/release-2.1.13.md
+++ b/releases/release-2.1.13.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.13 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.13/']
 ---
 

--- a/releases/release-2.1.14.md
+++ b/releases/release-2.1.14.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.14 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.14/']
 ---
 

--- a/releases/release-2.1.15.md
+++ b/releases/release-2.1.15.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.15 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.15/']
 ---
 

--- a/releases/release-2.1.16.md
+++ b/releases/release-2.1.16.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.16 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.16/']
 ---
 

--- a/releases/release-2.1.17.md
+++ b/releases/release-2.1.17.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.17 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.17/']
 ---
 

--- a/releases/release-2.1.18.md
+++ b/releases/release-2.1.18.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.18 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.18/']
 ---
 

--- a/releases/release-2.1.19.md
+++ b/releases/release-2.1.19.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.19 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.19/']
 ---
 

--- a/releases/release-2.1.2.md
+++ b/releases/release-2.1.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.2 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.2/']
 ---
 

--- a/releases/release-2.1.3.md
+++ b/releases/release-2.1.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.3 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.3/']
 ---
 

--- a/releases/release-2.1.4.md
+++ b/releases/release-2.1.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.4 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.4/']
 ---
 

--- a/releases/release-2.1.5.md
+++ b/releases/release-2.1.5.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.5 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.5/']
 ---
 

--- a/releases/release-2.1.6.md
+++ b/releases/release-2.1.6.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.6 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.6/']
 ---
 

--- a/releases/release-2.1.7.md
+++ b/releases/release-2.1.7.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.7 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.7/']
 ---
 

--- a/releases/release-2.1.8.md
+++ b/releases/release-2.1.8.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.8 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.8/']
 ---
 

--- a/releases/release-2.1.9.md
+++ b/releases/release-2.1.9.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1.9 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/2.1.9/']
 ---
 

--- a/releases/release-3.0-beta.md
+++ b/releases/release-3.0-beta.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0 Beta Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0beta/']
 ---
 

--- a/releases/release-3.0-ga.md
+++ b/releases/release-3.0-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0 GA Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0-ga/']
 ---
 

--- a/releases/release-3.0.0-beta.1.md
+++ b/releases/release-3.0.0-beta.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0 Beta.1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0.0-beta.1/']
 ---
 

--- a/releases/release-3.0.0-rc.1.md
+++ b/releases/release-3.0.0-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0.0-rc.1/']
 ---
 

--- a/releases/release-3.0.0-rc.2.md
+++ b/releases/release-3.0.0-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.2 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0.0-rc.2/']
 ---
 

--- a/releases/release-3.0.0-rc.3.md
+++ b/releases/release-3.0.0-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.0-rc.3 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0.0-rc.3/']
 ---
 

--- a/releases/release-3.0.1.md
+++ b/releases/release-3.0.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 3.0.1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/3.0.1/']
 ---
 

--- a/releases/release-notes.md
+++ b/releases/release-notes.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 版本发布历史
-category: release
 aliases: ['/docs-cn/v2.1/releases/rn/']
 ---
 

--- a/releases/release-pre-ga.md
+++ b/releases/release-pre-ga.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Pre-GA Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/prega/']
 ---
 

--- a/releases/release-rc.1.md
+++ b/releases/release-rc.1.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC1 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/rc1/']
 ---
 

--- a/releases/release-rc.2.md
+++ b/releases/release-rc.2.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC2 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/rc2/']
 ---
 

--- a/releases/release-rc.3.md
+++ b/releases/release-rc.3.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC3 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/rc3/']
 ---
 

--- a/releases/release-rc.4.md
+++ b/releases/release-rc.4.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB RC4 Release Notes
-category: Releases
 aliases: ['/docs-cn/v2.1/releases/rc4/']
 ---
 

--- a/report-issue.md
+++ b/report-issue.md
@@ -1,6 +1,5 @@
 ---
 title: 提交 Issue
-category: report issue
 ---
 
 # 提交 Issue

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 路线图
-category: Roadmap
 ---
 
 # TiDB 路线图

--- a/scale-tidb-using-ansible.md
+++ b/scale-tidb-using-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: 使用 TiDB Ansible 扩容缩容 TiDB 集群
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/scale/with-ansible/']
 ---
 

--- a/schema-object-names.md
+++ b/schema-object-names.md
@@ -1,6 +1,5 @@
 ---
 title: Schema Object Names
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/schema-object-names/']
 ---
 

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -1,6 +1,5 @@
 ---
 title: 与 MySQL 安全特性差异
-category: reference
 aliases: ['/docs-cn/v2.1/reference/security/compatibility/']
 ---
 

--- a/sql-optimization-concepts.md
+++ b/sql-optimization-concepts.md
@@ -1,6 +1,5 @@
 ---
 title: SQL 优化流程简介
-category: reference
 aliases: ['/docs-cn/v2.1/reference/performance/sql-optimizer-overview/']
 ---
 

--- a/sql-statements/sql-statement-add-column.md
+++ b/sql-statements/sql-statement-add-column.md
@@ -1,7 +1,6 @@
 ---
 title: ADD COLUMN
 summary: TiDB 数据库中 ADD COLUMN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/add-column/']
 ---
 

--- a/sql-statements/sql-statement-add-index.md
+++ b/sql-statements/sql-statement-add-index.md
@@ -1,7 +1,6 @@
 ---
 title: ADD INDEX
 summary: TiDB 数据库中 ADD INDEX 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/add-index/']
 ---
 

--- a/sql-statements/sql-statement-admin.md
+++ b/sql-statements/sql-statement-admin.md
@@ -1,6 +1,5 @@
 ---
 title: ADMIN 语句
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/admin/']
 ---
 

--- a/sql-statements/sql-statement-alter-database.md
+++ b/sql-statements/sql-statement-alter-database.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER DATABASE
 summary: TiDB 数据库中 ALTER DATABASE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/alter-database/']
 ---
 

--- a/sql-statements/sql-statement-alter-table.md
+++ b/sql-statements/sql-statement-alter-table.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER TABLE
 summary: TiDB 数据库中 ALTER TABLE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/alter-table/']
 ---
 

--- a/sql-statements/sql-statement-alter-user.md
+++ b/sql-statements/sql-statement-alter-user.md
@@ -1,7 +1,6 @@
 ---
 title: ALTER USER
 summary: TiDB 数据库中 ALTER USER 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/alter-user/']
 ---
 

--- a/sql-statements/sql-statement-analyze-table.md
+++ b/sql-statements/sql-statement-analyze-table.md
@@ -1,7 +1,6 @@
 ---
 title: ANALYZE TABLE
 summary: TiDB 数据库中 ANALYZE TABLE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/analyze-table/']
 ---
 

--- a/sql-statements/sql-statement-begin.md
+++ b/sql-statements/sql-statement-begin.md
@@ -1,7 +1,6 @@
 ---
 title: BEGIN
 summary: TiDB 数据库中 BEGIN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/begin/']
 ---
 

--- a/sql-statements/sql-statement-change-column.md
+++ b/sql-statements/sql-statement-change-column.md
@@ -1,7 +1,6 @@
 ---
 title: CHANGE COLUMN
 summary: TiDB 数据库中 CHANGE COLUMN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/change-column/']
 ---
 

--- a/sql-statements/sql-statement-commit.md
+++ b/sql-statements/sql-statement-commit.md
@@ -1,7 +1,6 @@
 ---
 title: COMMIT
 summary: TiDB 数据库中 COMMIT 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/commit/']
 ---
 

--- a/sql-statements/sql-statement-create-database.md
+++ b/sql-statements/sql-statement-create-database.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE DATABASE
 summary: TiDB 数据库中 CREATE DATABASE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/create-database/']
 ---
 

--- a/sql-statements/sql-statement-create-index.md
+++ b/sql-statements/sql-statement-create-index.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE INDEX
 summary: CREATE INDEX 在 TiDB 中的使用概况
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/create-index/']
 ---
 

--- a/sql-statements/sql-statement-create-table-like.md
+++ b/sql-statements/sql-statement-create-table-like.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE TABLE LIKE
 summary: TiDB 数据库中 CREATE TABLE LIKE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/create-table-like/']
 ---
 

--- a/sql-statements/sql-statement-create-table.md
+++ b/sql-statements/sql-statement-create-table.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE TABLE
 summary: TiDB 数据库中 CREATE TABLE 的使用概况
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/create-table/']
 ---
 

--- a/sql-statements/sql-statement-create-user.md
+++ b/sql-statements/sql-statement-create-user.md
@@ -1,7 +1,6 @@
 ---
 title: CREATE USER
 summary: TiDB 数据库中 CREATE USER 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/create-user/']
 ---
 

--- a/sql-statements/sql-statement-deallocate.md
+++ b/sql-statements/sql-statement-deallocate.md
@@ -1,7 +1,6 @@
 ---
 title: DEALLOCATE
 summary: TiDB 数据库中 DEALLOCATE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/deallocate/']
 ---
 

--- a/sql-statements/sql-statement-delete.md
+++ b/sql-statements/sql-statement-delete.md
@@ -1,7 +1,6 @@
 ---
 title: DELETE
 summary: TiDB 数据库中 DELETE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/delete/']
 ---
 

--- a/sql-statements/sql-statement-desc.md
+++ b/sql-statements/sql-statement-desc.md
@@ -1,7 +1,6 @@
 ---
 title: DESC
 summary: TiDB 数据库中 DESC 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/desc/']
 ---
 

--- a/sql-statements/sql-statement-describe.md
+++ b/sql-statements/sql-statement-describe.md
@@ -1,7 +1,6 @@
 ---
 title: DESCRIBE
 summary: TiDB 数据库中 DESCRIBE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/describe/']
 ---
 

--- a/sql-statements/sql-statement-do.md
+++ b/sql-statements/sql-statement-do.md
@@ -1,7 +1,6 @@
 ---
 title: DO | TiDB SQL Statement Reference
 summary: TiDB 数据库中 DO 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/do/']
 ---
 

--- a/sql-statements/sql-statement-drop-column.md
+++ b/sql-statements/sql-statement-drop-column.md
@@ -1,7 +1,6 @@
 ---
 title: DROP COLUMN
 summary: TiDB 数据库中 DROP COLUMN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/drop-column/']
 ---
 

--- a/sql-statements/sql-statement-drop-database.md
+++ b/sql-statements/sql-statement-drop-database.md
@@ -1,7 +1,6 @@
 ---
 title: DROP DATABASE
 summary: TiDB 数据库中 DROP DATABASE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/drop-database/']
 ---
 

--- a/sql-statements/sql-statement-drop-index.md
+++ b/sql-statements/sql-statement-drop-index.md
@@ -1,7 +1,6 @@
 ---
 title: DROP INDEX
 summary: TiDB 数据库中 DROP INDEX 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/drop-index/']
 ---
 

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -1,7 +1,6 @@
 ---
 title: DROP TABLE
 summary: TiDB 数据库中 DROP TABLE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/drop-table/']
 ---
 

--- a/sql-statements/sql-statement-drop-user.md
+++ b/sql-statements/sql-statement-drop-user.md
@@ -1,7 +1,6 @@
 ---
 title: DROP USER
 summary: TiDB 数据库中 DROP USER 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/drop-user/']
 ---
 

--- a/sql-statements/sql-statement-execute.md
+++ b/sql-statements/sql-statement-execute.md
@@ -1,7 +1,6 @@
 ---
 title: EXECUTE
 summary: TiDB 数据库中 EXECUTE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/execute/']
 ---
 

--- a/sql-statements/sql-statement-explain-analyze.md
+++ b/sql-statements/sql-statement-explain-analyze.md
@@ -1,7 +1,6 @@
 ---
 title: EXPLAIN ANALYZE
 summary: TiDB 数据库中 EXPLAIN ANALYZE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/explain-analyze/']
 ---
 

--- a/sql-statements/sql-statement-explain.md
+++ b/sql-statements/sql-statement-explain.md
@@ -1,7 +1,6 @@
 ---
 title: EXPLAIN
 summary: TiDB 数据库中 EXPLAIN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/explain/']
 ---
 

--- a/sql-statements/sql-statement-flush-privileges.md
+++ b/sql-statements/sql-statement-flush-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH PRIVILEGES
 summary: TiDB 数据库中 FLUSH PRIVILEGES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/flush-privileges/']
 ---
 

--- a/sql-statements/sql-statement-flush-status.md
+++ b/sql-statements/sql-statement-flush-status.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH STATUS
 summary: TiDB 数据库中 FLUSH STATUS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/flush-status/']
 ---
 

--- a/sql-statements/sql-statement-flush-tables.md
+++ b/sql-statements/sql-statement-flush-tables.md
@@ -1,7 +1,6 @@
 ---
 title: FLUSH TABLES
 summary: TiDB 数据库中 FLUSH TABLES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/flush-tables/']
 ---
 

--- a/sql-statements/sql-statement-grant-privileges.md
+++ b/sql-statements/sql-statement-grant-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: GRANT <privileges>
 summary: TiDB 数据库中 GRANT <privileges> 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/grant-privileges/']
 ---
 

--- a/sql-statements/sql-statement-insert.md
+++ b/sql-statements/sql-statement-insert.md
@@ -1,7 +1,6 @@
 ---
 title: INSERT
 summary: TiDB 数据库中 INSERT 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/insert/']
 ---
 

--- a/sql-statements/sql-statement-kill.md
+++ b/sql-statements/sql-statement-kill.md
@@ -1,7 +1,6 @@
 ---
 title: KILL [TIDB]
 summary: TiDB 数据库中 KILL [TIDB] 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/kill/']
 ---
 

--- a/sql-statements/sql-statement-load-data.md
+++ b/sql-statements/sql-statement-load-data.md
@@ -1,7 +1,6 @@
 ---
 title: LOAD DATA
 summary: TiDB 数据库中 LOAD DATA 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/load-data/']
 ---
 

--- a/sql-statements/sql-statement-load-stats.md
+++ b/sql-statements/sql-statement-load-stats.md
@@ -1,7 +1,6 @@
 ---
 title: LOAD STATS
 summary: TiDB 数据库中 LOAD STATS 的使用概况。
-category: reference
 ---
 
 # LOAD STATS

--- a/sql-statements/sql-statement-modify-column.md
+++ b/sql-statements/sql-statement-modify-column.md
@@ -1,7 +1,6 @@
 ---
 title: MODIFY COLUMN
 summary: TiDB 数据库中 MODIFY COLUMN 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/modify-column/']
 ---
 

--- a/sql-statements/sql-statement-prepare.md
+++ b/sql-statements/sql-statement-prepare.md
@@ -1,7 +1,6 @@
 ---
 title: PREPARE
 summary: TiDB 数据库中 PREPARE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/prepare/']
 ---
 

--- a/sql-statements/sql-statement-rename-index.md
+++ b/sql-statements/sql-statement-rename-index.md
@@ -1,7 +1,6 @@
 ---
 title: RENAME INDEX
 summary: TiDB 数据库中 RENAME INDEX 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/rename-index/']
 ---
 

--- a/sql-statements/sql-statement-rename-table.md
+++ b/sql-statements/sql-statement-rename-table.md
@@ -1,7 +1,6 @@
 ---
 title: RENAME TABLE
 summary: TiDB 数据库中 RENAME TABLE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/rename-table/']
 ---
 

--- a/sql-statements/sql-statement-replace.md
+++ b/sql-statements/sql-statement-replace.md
@@ -1,7 +1,6 @@
 ---
 title: REPLACE
 summary: TiDB 数据库中 REPLACE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/replace/']
 ---
 

--- a/sql-statements/sql-statement-revoke-privileges.md
+++ b/sql-statements/sql-statement-revoke-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: REVOKE <privileges>
 summary: TiDB 数据库中 REVOKE <privileges> 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/revoke-privileges/']
 ---
 

--- a/sql-statements/sql-statement-rollback.md
+++ b/sql-statements/sql-statement-rollback.md
@@ -1,7 +1,6 @@
 ---
 title: ROLLBACK
 summary: TiDB 数据库中 ROLLBACK 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/rollback/']
 ---
 

--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -1,7 +1,6 @@
 ---
 title: SELECT
 summary: TiDB 数据库中 SELECT 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/select/']
 ---
 

--- a/sql-statements/sql-statement-set-names.md
+++ b/sql-statements/sql-statement-set-names.md
@@ -1,7 +1,6 @@
 ---
 title: SET [NAMES|CHARACTER SET]
 summary: TiDB 数据库中 SET [NAMES|CHARACTER SET] 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/set-names/']
 ---
 

--- a/sql-statements/sql-statement-set-password.md
+++ b/sql-statements/sql-statement-set-password.md
@@ -1,7 +1,6 @@
 ---
 title: SET PASSWORD
 summary: TiDB 数据库中 SET PASSWORD 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/set-password/']
 ---
 

--- a/sql-statements/sql-statement-set-transaction.md
+++ b/sql-statements/sql-statement-set-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: SET TRANSACTION
 summary: TiDB 数据库中 SET TRANSACTION 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/set-transaction/']
 ---
 

--- a/sql-statements/sql-statement-set-variable.md
+++ b/sql-statements/sql-statement-set-variable.md
@@ -1,7 +1,6 @@
 ---
 title: SET [GLOBAL|SESSION] <variable>
 summary: TiDB 数据库中 SET [GLOBAL|SESSION] <variable> 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/set-variable/']
 ---
 

--- a/sql-statements/sql-statement-show-character-set.md
+++ b/sql-statements/sql-statement-show-character-set.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW CHARACTER SET
 summary: TiDB 数据库中 SHOW CHARACTER SET 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-character-set/']
 ---
 

--- a/sql-statements/sql-statement-show-collation.md
+++ b/sql-statements/sql-statement-show-collation.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW COLLATION
 summary: TiDB 数据库中 SHOW COLLATION 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-collation/']
 ---
 

--- a/sql-statements/sql-statement-show-columns-from.md
+++ b/sql-statements/sql-statement-show-columns-from.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] COLUMNS FROM
 summary: TiDB 数据库中 SHOW [FULL] COLUMNS FROM 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-columns-from/']
 ---
 

--- a/sql-statements/sql-statement-show-create-table.md
+++ b/sql-statements/sql-statement-show-create-table.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW CREATE TABLE
 summary: TiDB 数据库中 SHOW CREATE TABLE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-create-table/']
 ---
 

--- a/sql-statements/sql-statement-show-databases.md
+++ b/sql-statements/sql-statement-show-databases.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW DATABASES
 summary: TiDB 数据库中 SHOW DATABASES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-databases/']
 ---
 

--- a/sql-statements/sql-statement-show-engines.md
+++ b/sql-statements/sql-statement-show-engines.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW ENGINES
 summary: TiDB 数据库中 SHOW ENGINES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-engines/']
 ---
 

--- a/sql-statements/sql-statement-show-errors.md
+++ b/sql-statements/sql-statement-show-errors.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW ERRORS
 summary: TiDB 数据库中 SHOW ERRORS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-errors/']
 ---
 

--- a/sql-statements/sql-statement-show-fields-from.md
+++ b/sql-statements/sql-statement-show-fields-from.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] FIELDS FROM
 summary: TiDB 数据库中 SHOW [FULL] FIELDS FROM 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-fields-from/']
 ---
 

--- a/sql-statements/sql-statement-show-grants.md
+++ b/sql-statements/sql-statement-show-grants.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW GRANTS
 summary: TiDB 数据库中 SHOW GRANTS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-grants/']
 ---
 

--- a/sql-statements/sql-statement-show-index.md
+++ b/sql-statements/sql-statement-show-index.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW INDEX [FROM|IN]
 summary: TiDB 数据库中 SHOW INDEX [FROM|IN] 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-index/']
 ---
 

--- a/sql-statements/sql-statement-show-indexes.md
+++ b/sql-statements/sql-statement-show-indexes.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW INDEXES [FROM|IN]
 summary: TiDB 数据库中 SHOW INDEXES [FROM|IN] 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-indexes/']
 ---
 

--- a/sql-statements/sql-statement-show-keys.md
+++ b/sql-statements/sql-statement-show-keys.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW KEYS [FROM|IN]
 summary: TiDB 数据库中 SHOW KEYS [FROM|IN] 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-keys/']
 ---
 

--- a/sql-statements/sql-statement-show-privileges.md
+++ b/sql-statements/sql-statement-show-privileges.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW PRIVILEGES
 summary: TiDB 数据库中 SHOW PRIVILEGES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-privileges/']
 ---
 

--- a/sql-statements/sql-statement-show-processlist.md
+++ b/sql-statements/sql-statement-show-processlist.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] PROCESSLIST
 summary: TiDB 数据库中 SHOW [FULL] PROCESSLIST 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-processlist/']
 ---
 

--- a/sql-statements/sql-statement-show-schemas.md
+++ b/sql-statements/sql-statement-show-schemas.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW SCHEMAS
 summary: TiDB 数据库中 SHOW SCHEMAS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-schemas/']
 ---
 

--- a/sql-statements/sql-statement-show-status.md
+++ b/sql-statements/sql-statement-show-status.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [GLOBAL|SESSION] STATUS
 summary: TiDB 数据库中 SHOW [GLOBAL|SESSION] STATUS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-status/']
 ---
 

--- a/sql-statements/sql-statement-show-table-regions.md
+++ b/sql-statements/sql-statement-show-table-regions.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW TABLE REGIONS
 summary: 了解如何使用 TiDB 数据库中的 SHOW TABLE REGIONS。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-table-regions/']
 ---
 

--- a/sql-statements/sql-statement-show-table-status.md
+++ b/sql-statements/sql-statement-show-table-status.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW TABLE STATUS
 summary: TiDB 数据库中 SHOW TABLE STATUS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-table-status/']
 ---
 

--- a/sql-statements/sql-statement-show-tables.md
+++ b/sql-statements/sql-statement-show-tables.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [FULL] TABLES
 summary: TiDB 数据库中 SHOW [FULL] TABLES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-tables/']
 ---
 

--- a/sql-statements/sql-statement-show-variables.md
+++ b/sql-statements/sql-statement-show-variables.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW [GLOBAL|SESSION] VARIABLES
 summary: TiDB 数据库中 SHOW [GLOBAL|SESSION] VARIABLES 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-variables/']
 ---
 

--- a/sql-statements/sql-statement-show-warnings.md
+++ b/sql-statements/sql-statement-show-warnings.md
@@ -1,7 +1,6 @@
 ---
 title: SHOW WARNINGS
 summary: TiDB 数据库中 SHOW WARNINGS 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/show-warnings/']
 ---
 

--- a/sql-statements/sql-statement-split-region.md
+++ b/sql-statements/sql-statement-split-region.md
@@ -1,6 +1,5 @@
 ---
 title: Split Region 使用文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/split-region/']
 ---
 

--- a/sql-statements/sql-statement-start-transaction.md
+++ b/sql-statements/sql-statement-start-transaction.md
@@ -1,7 +1,6 @@
 ---
 title: START TRANSACTION
 summary: TiDB 数据库中 START TRANSACTION 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/start-transaction/']
 ---
 

--- a/sql-statements/sql-statement-trace.md
+++ b/sql-statements/sql-statement-trace.md
@@ -1,7 +1,6 @@
 ---
 title: TRACE
 summary: TiDB 数据库中 TRACE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/trace/']
 ---
 

--- a/sql-statements/sql-statement-truncate.md
+++ b/sql-statements/sql-statement-truncate.md
@@ -1,7 +1,6 @@
 ---
 title: TRUNCATE
 summary: TiDB 数据库中 TRUNCATE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/truncate/']
 ---
 

--- a/sql-statements/sql-statement-update.md
+++ b/sql-statements/sql-statement-update.md
@@ -1,7 +1,6 @@
 ---
 title: UPDATE
 summary: TiDB 数据库中 UPDATE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/update/']
 ---
 

--- a/sql-statements/sql-statement-use.md
+++ b/sql-statements/sql-statement-use.md
@@ -1,7 +1,6 @@
 ---
 title: USE
 summary: TiDB 数据库中 USE 的使用概况。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/statements/use/']
 ---
 

--- a/statistics.md
+++ b/statistics.md
@@ -1,6 +1,5 @@
 ---
 title: 统计信息简介
-category: reference
 aliases: ['/docs-cn/v2.1/reference/performance/statistics/']
 ---
 

--- a/support.md
+++ b/support.md
@@ -1,6 +1,5 @@
 ---
 title: 支持资源
-category: resources
 aliases: ['/docs-cn/v2.1/support-resources/']
 ---
 

--- a/sync-diff-inspector/route-diff.md
+++ b/sync-diff-inspector/route-diff.md
@@ -1,6 +1,5 @@
 ---
 title: 不同库名或表名的数据校验
-category: tools
 aliases: ['/docs-cn/v2.1/reference/tools/sync-diff-inspector/route-diff/']
 ---
 

--- a/sync-diff-inspector/shard-diff.md
+++ b/sync-diff-inspector/shard-diff.md
@@ -1,6 +1,5 @@
 ---
 title: 分库分表场景下的数据校验
-category: tools
 aliases: ['/docs-cn/v2.1/reference/tools/sync-diff-inspector/shard-diff/']
 ---
 

--- a/sync-diff-inspector/sync-diff-inspector-overview.md
+++ b/sync-diff-inspector/sync-diff-inspector-overview.md
@@ -1,6 +1,5 @@
 ---
 title: sync-diff-inspector 用户文档
-category: tools
 aliases: ['/docs-cn/v2.1/reference/tools/sync-diff-inspector/overview/','/docs-cn/v2.1/reference/tools/sync-diff-inspector/']
 ---
 

--- a/sync-diff-inspector/upstream-downstream-diff.md
+++ b/sync-diff-inspector/upstream-downstream-diff.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 主从集群的数据校验
-category: tools
 aliases: ['/docs-cn/v2.1/reference/tools/sync-diff-inspector/tidb-diff/']
 ---
 

--- a/syncer-overview.md
+++ b/syncer-overview.md
@@ -1,6 +1,5 @@
 ---
 title: Syncer 使用文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/syncer/']
 ---
 

--- a/system-tables/system-table-information-schema.md
+++ b/system-tables/system-table-information-schema.md
@@ -1,6 +1,5 @@
 ---
 title: Information Schema
-category: reference
 aliases: ['/docs-cn/v2.1/reference/system-databases/information-schema/']
 ---
 

--- a/system-tables/system-table-overview.md
+++ b/system-tables/system-table-overview.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 系统表
-category: reference
 aliases: ['/docs-cn/v2.1/reference/system-databases/mysql/']
 ---
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -1,6 +1,5 @@
 ---
 title: 系统变量
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/tidb-server/mysql-variables/']
 ---
 

--- a/test-deployment-using-docker.md
+++ b/test-deployment-using-docker.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Docker 部署方案
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/deploy/orchestrated/docker/']
 ---
 

--- a/tidb-binlog/binlog-slave-client.md
+++ b/tidb-binlog/binlog-slave-client.md
@@ -1,6 +1,5 @@
 ---
 title: Binlog Slave Client 用户文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/binlog-slave-client/','/docs-cn/v2.1/reference/tools/tidb-binlog/binlog-slave-client/']
 ---
 

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 集群部署
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/deploy/','/docs-cn/v2.1/how-to/deploy/tidb-binlog/','/docs-cn/v2.1/reference/tools/tidb-binlog/deploy/']
 ---
 

--- a/tidb-binlog/handle-tidb-binlog-errors.md
+++ b/tidb-binlog/handle-tidb-binlog-errors.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 常见错误修复
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/troubleshoot/error-handling/']
 ---
 

--- a/tidb-binlog/maintain-tidb-binlog-cluster.md
+++ b/tidb-binlog/maintain-tidb-binlog-cluster.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 集群运维
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/maintain/','/docs-cn/v2.1/how-to/maintain/tidb-binlog/','/docs-cn/v2.1/reference/tools/tidb-binlog/maintain/']
 ---
 

--- a/tidb-binlog/monitor-tidb-binlog-cluster.md
+++ b/tidb-binlog/monitor-tidb-binlog-cluster.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 集群监控
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/monitor/','/docs-cn/v2.1/how-to/monitor/tidb-binlog/','/docs-cn/v2.1/reference/tools/tidb-binlog/monitor/']
 ---
 

--- a/tidb-binlog/tidb-binlog-configuration-file.md
+++ b/tidb-binlog/tidb-binlog-configuration-file.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 配置说明
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/configs/']
 ---
 

--- a/tidb-binlog/tidb-binlog-faq.md
+++ b/tidb-binlog/tidb-binlog-faq.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 常见问题
-category: FAQ
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/faq/','/docs-cn/v2.1/faq/tidb-binlog/','/docs-cn/v2.1/reference/tools/tidb-binlog/faq/']
 ---
 

--- a/tidb-binlog/tidb-binlog-glossary.md
+++ b/tidb-binlog/tidb-binlog-glossary.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Binlog 术语表
 summary: 学习 TiDB Binlog 相关术语
-category: glossary
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/glossary/']
 ---
 

--- a/tidb-binlog/tidb-binlog-kafka-deployment.md
+++ b/tidb-binlog/tidb-binlog-kafka-deployment.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog kafka 部署方案
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/tidb-binlog-kafka/','/docs-cn/v2.1/reference/tools/tidb-binlog/tidb-binlog-kafka/']
 ---
 

--- a/tidb-binlog/tidb-binlog-local-deployment.md
+++ b/tidb-binlog/tidb-binlog-local-deployment.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog Local 部署方案
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/tidb-binlog-local/','/docs-cn/v2.1/reference/tools/tidb-binlog/tidb-binlog-local/']
 ---
 

--- a/tidb-binlog/tidb-binlog-overview.md
+++ b/tidb-binlog/tidb-binlog-overview.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 简介
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/overview/','/docs-cn/v2.1/reference/tidb-binlog-overview/','/docs-cn/v2.1/reference/tools/tidb-binlog/overview/']
 ---
 

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -1,6 +1,5 @@
 ---
 title: Reparo 使用文档
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/reparo/','/docs-cn/v2.1/reference/tools/tidb-binlog/reparo/']
 ---
 

--- a/tidb-binlog/troubleshoot-tidb-binlog.md
+++ b/tidb-binlog/troubleshoot-tidb-binlog.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 故障诊断
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/troubleshoot/binlog/','/docs-cn/v2.1/how-to/troubleshoot/tidb-binlog/']
 ---
 

--- a/tidb-binlog/upgrade-tidb-binlog.md
+++ b/tidb-binlog/upgrade-tidb-binlog.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Binlog 版本升级方法
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tidb-binlog/upgrade/','/docs-cn/v2.1/how-to/upgrade/tidb-binlog/','/docs-cn/v2.1/reference/tools/tidb-binlog/upgrade/']
 ---
 

--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 配置文件描述
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/tidb-server/configuration-file/']
 ---
 

--- a/tidb-control.md
+++ b/tidb-control.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Control 使用说明
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-control/']
 ---
 

--- a/tidb-lightning/deploy-tidb-lightning.md
+++ b/tidb-lightning/deploy-tidb-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 部署与执行
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/deployment/']
 ---
 

--- a/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
+++ b/tidb-lightning/migrate-from-csv-using-tidb-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: CSV 支持
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/csv/']
 ---
 

--- a/tidb-lightning/monitor-tidb-lightning.md
+++ b/tidb-lightning/monitor-tidb-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 监控告警
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/monitor/']
 ---
 

--- a/tidb-lightning/tidb-lightning-checkpoints.md
+++ b/tidb-lightning/tidb-lightning-checkpoints.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 断点续传
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/checkpoints/']
 ---
 

--- a/tidb-lightning/tidb-lightning-configuration.md
+++ b/tidb-lightning/tidb-lightning-configuration.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning 配置参数
 summary: 使用配置文件或命令行配置 TiDB Lightning。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/config/']
 ---
 

--- a/tidb-lightning/tidb-lightning-faq.md
+++ b/tidb-lightning/tidb-lightning-faq.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 常见问题
-category: FAQ
 aliases: ['/docs-cn/v2.1/faq/tidb-lightning/']
 ---
 

--- a/tidb-lightning/tidb-lightning-glossary.md
+++ b/tidb-lightning/tidb-lightning-glossary.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning 术语表
 summary: 了解 TiDB Lightning 相关的术语及定义。
-category: glossary
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/glossary/']
 ---
 

--- a/tidb-lightning/tidb-lightning-overview.md
+++ b/tidb-lightning/tidb-lightning-overview.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 简介
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/overview/']
 ---
 

--- a/tidb-lightning/tidb-lightning-table-filter.md
+++ b/tidb-lightning/tidb-lightning-table-filter.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning 表库过滤
 summary: 使用黑白名单把一些表剔出要导入的范围。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/table-filter/']
 ---
 

--- a/tidb-lightning/tidb-lightning-web-interface.md
+++ b/tidb-lightning/tidb-lightning-web-interface.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB Lightning Web 界面
 summary: 了解 TiDB Lightning 的服务器模式——通过 Web 界面来控制 TiDB Lightning。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tidb-lightning/web/']
 ---
 

--- a/tidb-monitoring-framework.md
+++ b/tidb-monitoring-framework.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 监控框架概述
-category: monitoring
 aliases: ['/docs-cn/v2.1/how-to/monitor/overview/']
 ---
 

--- a/tidb-specific-system-variables.md
+++ b/tidb-specific-system-variables.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 专用系统变量和语法
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/tidb-server/tidb-specific-variables/']
 ---
 

--- a/tidb-troubleshooting-map.md
+++ b/tidb-troubleshooting-map.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 集群问题导图
 summary: 了解如何处理 TiDB 集群常见问题。
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/troubleshoot/diagnose-map/']
 ---
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1,6 +1,5 @@
 ---
 title: TiKV 配置参数
-category: reference
 aliases: ['/docs-cn/v2.1/reference/configuration/tikv-server/configuration/']
 ---
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -1,6 +1,5 @@
 ---
 title: TiKV Control 使用说明
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tools/tikv-control/']
 ---
 

--- a/tispark-overview.md
+++ b/tispark-overview.md
@@ -1,6 +1,5 @@
 ---
 title: TiSpark 用户指南
-category: reference
 aliases: ['/docs-cn/v2.1/reference/tispark/']
 ---
 

--- a/topn-limit-push-down.md
+++ b/topn-limit-push-down.md
@@ -1,6 +1,5 @@
 ---
 title: TopN 和 Limit 下推
-category: performance
 ---
 
 # TopN 和 Limit 下推

--- a/transaction-isolation-levels.md
+++ b/transaction-isolation-levels.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 事务隔离级别
 summary: 了解 TiDB 事务的隔离级别。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/transactions/transaction-isolation/']
 ---
 

--- a/transaction-overview.md
+++ b/transaction-overview.md
@@ -1,7 +1,6 @@
 ---
 title: TiDB 事务概览
 summary: 了解 TiDB 中的事务。
-category: reference
 aliases: ['/docs-cn/v2.1/reference/transactions/overview/']
 ---
 

--- a/troubleshoot-tidb-cluster.md
+++ b/troubleshoot-tidb-cluster.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 集群故障诊断
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/troubleshoot/cluster-setup/']
 ---
 

--- a/troubleshoot-tidb-lightning.md
+++ b/troubleshoot-tidb-lightning.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB Lightning 错误排解
-category: reference
 aliases: ['/docs-cn/v2.1/how-to/troubleshoot/tidb-lightning/']
 ---
 

--- a/tune-operating-system.md
+++ b/tune-operating-system.md
@@ -1,6 +1,5 @@
 ---
 title: 操作系统性能参数调优
-category: reference
 ---
 
 # 操作系统性能参数调优

--- a/tune-tikv-performance.md
+++ b/tune-tikv-performance.md
@@ -1,6 +1,5 @@
 ---
 title: TiKV 性能参数调优
-category: reference
 aliases: ['/docs-cn/v2.1/reference/performance/tune-tikv/']
 ---
 

--- a/upgrade-tidb-using-ansible.md
+++ b/upgrade-tidb-using-ansible.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 2.1 升级操作指南
-category: how-to
 aliases: ['/docs-cn/v2.1/how-to/upgrade/from-previous-version/','/docs-cn/op-guide/tidb-v2.1-upgrade-guide/','/docs-cn/v2.1/how-to/upgrade/to-tidb-2.1/','/docs-cn/dev/how-to/upgrade/to-tidb-2.1/','/docs-cn/v3.0/how-to/upgrade/to-tidb-2.1/',/docs-cn/v3.1/how-to/upgrade/to-tidb-2.1/,'/docs-cn/v2.1/how-to/upgrade/rolling-updates-with-ansible/']
 ---
 

--- a/user-account-management.md
+++ b/user-account-management.md
@@ -1,6 +1,5 @@
 ---
 title: TiDB 用户账户管理
-category: reference
 aliases: ['/docs-cn/v2.1/reference/security/user-account-management/']
 ---
 

--- a/user-defined-variables.md
+++ b/user-defined-variables.md
@@ -1,6 +1,5 @@
 ---
 title: 用户自定义变量
-category: reference
 aliases: ['/docs-cn/v2.1/reference/sql/language-structure/user-defined-variables/']
 ---
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Remove `category` in metadata.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):
