### PR TITLE
Emphasize that statement summary history tables may lose after TiDB rebooting

### DIFF
--- a/statement-summary-tables.md
+++ b/statement-summary-tables.md
@@ -128,7 +128,7 @@ set global tidb_stmt_summary_history_size = 24;
 
 Statement summary tables 现在还存在以下限制：
 
-- TiDB server 重启后 statement summary 会丢失。因为 statement summary tables 是内存表，不会持久化数据，所以一旦 server 被重启，statement summary 随之丢失。
+- TiDB server 重启后以上所有 4 张表的 statement summary 都会丢失。因为 statement summary tables 全部都是内存表，不会持久化数据，所以一旦 server 被重启，statement summary 随之丢失。
 
 ## 排查示例
 

--- a/statement-summary-tables.md
+++ b/statement-summary-tables.md
@@ -128,7 +128,7 @@ set global tidb_stmt_summary_history_size = 24;
 
 Statement summary tables 现在还存在以下限制：
 
-- TiDB server 重启后以上所有 4 张表的 statement summary 都会丢失。因为 statement summary tables 全部都是内存表，不会持久化数据，所以一旦 server 被重启，statement summary 随之丢失。
+- TiDB server 重启后以上 4 张表的 statement summary 会全部丢失。因为 statement summary tables 全部都是内存表，不会持久化数据，所以一旦 server 被重启，statement summary 随之丢失。
 
 ## 排查示例
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Statement summary tables include history tables and cluster tables, but users may take it for granted that statement summary table is `statements_summary` and history tables won't lose after TiDB rebooting.

This PR emphasize that all tables, including history tables and cluster tables, may lose after TiDB rebooting.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- N/A

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
