### PR TITLE
auth: Remove note about MySQL 8.0 auth plugin

### DIFF
--- a/connectors-and-apis.md
+++ b/connectors-and-apis.md
@@ -23,10 +23,6 @@ TiDB 兼容 MySQL(5.6、5.7) 的所有连接器和 API，包括：
 + [MySQL Eiffel Wrapper](https://dev.mysql.com/doc/refman/5.7/en/apis-eiffel.html)
 + [Mysql Go API](https://github.com/go-sql-driver/mysql)
 
-> **注意：**
->
-> 若要使用 MySQL 8.0 的连接器连接到 TiDB，你必须显式地指定 `default-auth=mysql_native_password`，因为 `mysql_native_password` 不再是[默认的插件](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password)。
-
 ## 使用 MySQL 连接器连接 TiDB
 
 Oracle 官方提供了以下 API，TiDB 可以兼容所有这些 API。

--- a/faq/tidb-faq.md
+++ b/faq/tidb-faq.md
@@ -37,16 +37,6 @@ TiDB 目前还不支持触发器、存储过程、自定义函数、外键，除
 
 详情参见[与 MySQL 兼容性对比](/mysql-compatibility.md)。
 
-使用 MySQL 8.0 客户端时，如果遇到无法登陆的问题，可以尝试指定 `default-auth` 和 `default-character-set` 参数：
-
-{{< copyable "shell-regular" >}}
-
-```shell
-mysql -h 127.0.0.1 -u root -P 4000 --default-auth=mysql_native_password --default-character-set=utf8
-```
-
-无法登陆的原因是 MySQL 8.0 会更改了 MySQL 5.7 默认的[密码加密方式](/security-compatibility-with-mysql.md)，所以需要添加以上参数指定使用旧的加密方式。
-
 #### 1.1.7 TiDB 支持分布式事务吗？
 
 支持。无论是一个地方的几个节点，还是[跨多个数据中心的多个节点](/multi-data-centers-in-one-city-deployment.md)，TiDB 均支持 ACID 分布式事务。

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -8,9 +8,9 @@ aliases: ['/docs-cn/dev/security-compatibility-with-mysql/','/docs-cn/dev/refere
 除以下功能外，TiDB 支持与 MySQL 5.7 类似的安全特性。
 
 - 仅支持 `mysql_native_password` 密码验证或证书验证登陆方案。
-    - MySQL 8.0 中，`mysql_native_password` 不再是[默认/推荐的插件](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password)。若要使用 MySQL 8.0 的连接器连接到 TiDB，你必须显式地指定 `default-auth=mysql_native_password`。
 - 不支持外部身份验证方式（如 LDAP）。
 - 不支持列级别权限设置。
 - 不支持密码过期，最后一次密码变更记录以及密码生存期。[#9709](https://github.com/pingcap/tidb/issues/9709)
 - 不支持权限属性 `max_questions`，`max_updated`，`max_connections` 以及 `max_user_connections`。
+
 - 不支持密码验证。[#9741](https://github.com/pingcap/tidb/issues/9741)

--- a/security-compatibility-with-mysql.md
+++ b/security-compatibility-with-mysql.md
@@ -12,5 +12,4 @@ aliases: ['/docs-cn/dev/security-compatibility-with-mysql/','/docs-cn/dev/refere
 - 不支持列级别权限设置。
 - 不支持密码过期，最后一次密码变更记录以及密码生存期。[#9709](https://github.com/pingcap/tidb/issues/9709)
 - 不支持权限属性 `max_questions`，`max_updated`，`max_connections` 以及 `max_user_connections`。
-
 - 不支持密码验证。[#9741](https://github.com/pingcap/tidb/issues/9741)

--- a/user-account-management.md
+++ b/user-account-management.md
@@ -27,10 +27,6 @@ mysql --port 4000 --user xxx --password
 mysql -P 4000 -u xxx -p
 ```
 
-> **Note:**
->
-> 若要使用 MySQL 8.0 的连接器连接到 TiDB，你必须显式地指定 `default-auth=mysql_native_password`，因为 `mysql_native_password` 不再是[默认的插件](https://dev.mysql.com/doc/refman/8.0/en/upgrading-from-previous-series.html#upgrade-caching-sha2-password)。
-
 ## 添加用户
 
 添加用户有两种方式：


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
Remove note about MySQL 8.0 auth plugin.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/3896
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
