### PR TITLE
tidb: update autocommit behavior description of pessimistic transactions

### DIFF
--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -97,9 +97,9 @@ BEGIN /*T! PESSIMISTIC */;
 
 5. autocommit 事务优先采用乐观事务提交。
     
-    使用悲观事务模型时，autocommit 事务首先尝试使用开销更小的乐观事务模式提交，如果发生了写冲突，重试时才会使用悲观事务提交。所以 `tidb_retry_limit = 0` 时，autocommit 事务遇到写冲突仍会报 `Write Conflict` 错误。
+    使用悲观事务模型时，autocommit 事务首先尝试使用开销更小的乐观事务模式提交。如果发生了写冲突，重试时才会使用悲观事务提交。所以 `tidb_retry_limit = 0` 时，autocommit 事务遇到写冲突仍会报 `Write Conflict` 错误。
 
-    自动提交的 select for update 语句不会等锁。
+    自动提交的 `SELECT FOR UPDATE` 语句不会等锁。
 
 6. 对语句中 `EMBEDDED SELECT` 读到的相关数据不会加锁。
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -95,11 +95,11 @@ BEGIN /*T! PESSIMISTIC */;
 
 4. `START TRANSACTION WITH CONSISTENT SNAPSHOT` 之后，MySQL 仍然可以读取到之后在其他事务创建的表，而 TiDB 不能。
 
-5. autocommit 事务不支持悲观锁。
+5. autocommit 事务优先采用乐观事务提交。
+    
+    使用悲观事务模型时，autocommit 事务首先尝试使用开销更小的乐观事务模式提交，如果发生了写冲突，重试时才会使用悲观事务提交。所以 `tidb_retry_limit = 0` 时，autocommit 事务遇到写冲突仍会报 `Write Conflict` 错误。
 
-    所有自动提交的语句都不会加悲观锁，该类语句在用户侧感知不到区别，因为悲观事务的本质是把整个事务的重试变成了单个 DML 的重试，autocommit 事务即使在 TiDB 关闭重试时也会自动重试，效果和悲观事务相同。
-
-    自动提交的 select for update 语句也不会等锁。
+    自动提交的 select for update 语句不会等锁。
 
 6. 对语句中 `EMBEDDED SELECT` 读到的相关数据不会加锁。
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

After TiDB v4.0.6, autocommit transactions will turn to use pessimistic transaction in retries.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

This PR supercedes https://github.com/pingcap/docs-cn/pull/4750

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
