### PR TITLE
chore: remove copyable code snippet when generate PDF

### DIFF
--- a/scripts/merge_by_toc.py
+++ b/scripts/merge_by_toc.py
@@ -21,6 +21,8 @@ image_link_pattern = re.compile(r'!\[(.*?)\]\((.*?)\)')
 level_pattern = re.compile(r'(\s*[\-\+]+)\s')
 # match all headings
 heading_patthern = re.compile(r'(^#+|\n#+)\s')
+# match copyable snippet code
+copyable_snippet_pattern = re.compile(r'{{< copyable .* >}}')
 
 
 entry_file = "TOC.md"
@@ -138,14 +140,9 @@ def replace_heading_func(diff_level=0):
 
     return replace_heading
 
-def replace_img_link(match):
-    full = match.group(0)
-    link_name = match.group(1)
-    link = match.group(2)
-
-    if link.endswith('.png'):
-        fname = os.path.basename(link)
-        return '![%s](./media/%s)' % (link_name, fname)
+# remove copyable snippet code
+def remove_copyable(match):
+    return ''
 
 # stage 3, concat files
 for type_, level, name in followups:
@@ -158,7 +155,7 @@ for type_, level, name in followups:
             with open(name) as fp:
                 chapter = fp.read()
                 chapter = replace_link_wrap(chapter, name)
-                # chapter = image_link_pattern.sub(replace_img_link, chapter)
+                chapter = copyable_snippet_pattern.sub(remove_copyable, chapter)
 
                 # fix heading level
                 diff_level = level - heading_patthern.findall(chapter)[0].count('#')


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)
Remove `copyable` code snippet when generate PDF.
<!-- You **must** choose the TiDB version(s) that your changes apply to. Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [x] v2.1 (TiDB 2.1 versions)

<!-- For contributors with **WRITE ACCESS** in this repo:
If you select **two or more** versions from above, to trigger the bot to cherry-pick this PR to your desired release branch(es), you **must** add labels such as "needs-cherry-pick-4.0", "needs-cherry-pick-3.1", "needs-cherry-pick-3.0", or "needs-cherry-pick-2.1" on the right side of this PR page.-->

### What is the related PR or file link(s)?

<!--Give us some reference link(s) that might help quickly review and merge your PR.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

<!-- Provide as much information as possible so that reviewers can review your changes more efficiently.
If you are not sure of the options, leave it as it is. -->

- [ ] Delete files
- [ ] Change aliases
- [ ] Have version specific changes <!-- If yes, please add the label "version-specific-changes-required"-->
- [ ] Might cause conflicts
