### PR TITLE
update the local storage description from 'mocktikv' to 'unistore'

### DIFF
--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -94,11 +94,11 @@ aliases: ['/docs-cn/dev/command-line-flags-for-tidb-configuration/','/docs-cn/de
 
 ## `--path`
 
-+ 对于本地存储引擎 "mocktikv" 来说，path 指定的是实际的数据存放路径
-+ 当 `--store = tikv` 时，必须指定 path；当 `--store = mocktikv` 时，如果不指定 path，会使用默认值。
++ 对于本地存储引擎 "unistore" 来说，path 指定的是实际的数据存放路径
++ 当 `--store = tikv` 时，必须指定 path；当 `--store = unistore` 时，如果不指定 path，会使用默认值。
 + 对于 "TiKV" 存储引擎来说，path 指定的是实际的 PD 地址。假如在 192.168.100.113:2379、192.168.100.114:2379 和 192.168.100.115:2379 上面部署了 PD，那么 path 为 "192.168.100.113:2379, 192.168.100.114:2379, 192.168.100.115:2379"
 + 默认："/tmp/tidb"
-+ 可以通过 `tidb-server --store=mocktikv --path=""` 来启动一个纯内存引擎的 TiDB
++ 可以通过 `tidb-server --store=unistore --path=""` 来启动一个纯内存引擎的 TiDB
 
 ## `--tmp-storage-path`
 
@@ -160,8 +160,8 @@ aliases: ['/docs-cn/dev/command-line-flags-for-tidb-configuration/','/docs-cn/de
 ## `--store`
 
 + 用来指定 TiDB 底层使用的存储引擎
-+ 默认："mocktikv"
-+ 可以选择 "mocktikv"（本地存储引擎）或者 "tikv"（分布式存储引擎）
++ 默认："unistore"
++ 可以选择 "unistore"（本地存储引擎）或者 "tikv"（分布式存储引擎）
 
 ## `--token-limit`
 

--- a/sql-statements/sql-statement-restore.md
+++ b/sql-statements/sql-statement-restore.md
@@ -22,7 +22,7 @@ aliases: ['/docs-cn/dev/sql-statements/sql-statement-restore/']
 
 一次只能执行一个 `BACKUP` 和 `RESTORE` 任务。如果 TiDB server 上已经在执行一个 `BACKUP` 或 `RESTORE` 语句，新的 `RESTORE` 将等待前面所有的任务完成后再执行。
 
-`RESTORE` 只能在 "tikv" 存储引擎上使用，如果使用 "mocktikv" 存储引擎，`RESTORE` 操作会失败。
+`RESTORE` 只能在 "tikv" 存储引擎上使用，如果使用 "unistore" 存储引擎，`RESTORE` 操作会失败。
 
 ## 语法图
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

In 'dev' and 'v5.0' version, the default value of `--store` TiDB command-line argument has been changed to 'unistore'.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: NA
- Other reference link(s): https://github.com/pingcap/tidb/pull/17674

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
