### PR TITLE
tidb: Fix default value of grpc-connection-count

### DIFF
--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -446,7 +446,7 @@ prepare 语句的 plan cache 设置。
 ### `grpc-connection-count`
 
 + 跟每个 TiKV 之间建立的最大连接数。
-+ 默认值：16
++ 默认值：4
 
 ### `grpc-keepalive-time`
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Changed default value of `tikv-client.grpc-connection-count` from 16 to 4. This default value is actually changed before releasing 4.0, and is included in all 4.x versions, without updating the document.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
