### PR TITLE
Update the default value of grpc-raft-conn-num

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -43,7 +43,7 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 ### `grpc-raft-conn-num`
 
 + tikv 节点之间用于 raft 通讯的链接最大数量。
-+ 默认值：10
++ 默认值：1
 + 最小值：1
 
 ### `grpc-stream-initial-window-size`

--- a/tune-tikv-performance.md
+++ b/tune-tikv-performance.md
@@ -42,7 +42,7 @@ log-level = "info"
 # gRPC 线程池大小
 # grpc-concurrency = 4
 # TiKV 每个实例之间的 gRPC 连接数
-# grpc-raft-conn-num = 10
+# grpc-raft-conn-num = 1
 
 # TiDB 过来的大部分读请求都会发送到 TiKV 的 Coprocessor 进行处理，该参数用于设置
 # coprocessor 线程的个数，如果业务是读请求比较多，增加 coprocessor 的线程数，但应比系统的
@@ -121,7 +121,7 @@ region-split-check-diff = "32MB"
 # RocksDB 能够打开的最大文件句柄数。
 # max-open-files = 40960
 
-# RocksDB MANIFEST 文件的大小限制. # 更详细的信息请参考：https://github.com/facebook/rocksdb/wiki/MANIFEST
+# RocksDB MANIFEST 文件的大小限制 # 更详细的信息请参考：https://github.com/facebook/rocksdb/wiki/MANIFEST
 max-manifest-file-size = "20MB"
 
 # RocksDB write-ahead logs 目录。如果机器上有两块盘，可以将 RocksDB 的数据和 WAL 日志放在


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

Update the default value of `grpc-raft-conn-num` from `10` to `1`.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [ ] master (the latest development version)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [x] v3.1 (TiDB 3.1 versions)
- [x] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):https://github.com/pingcap/docs-cn/pull/5669/files#r603843190

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
