### PR TITLE
sql-statements, information-schema: add `END_TIME` field for table `ANALYZE_STATUS`

### DIFF
--- a/information-schema/information-schema-analyze-status.md
+++ b/information-schema/information-schema-analyze-status.md
@@ -24,9 +24,10 @@ DESC analyze_status;
 | JOB_INFO       | varchar(64)         | YES  |      | NULL    |       |
 | PROCESSED_ROWS | bigint(20) unsigned | YES  |      | NULL    |       |
 | START_TIME     | datetime            | YES  |      | NULL    |       |
+| END_TIME       | datetime            | YES  |      | NULL    |       |
 | STATE          | varchar(64)         | YES  |      | NULL    |       |
 +----------------+---------------------+------+------+---------+-------+
-7 rows in set (0.00 sec)
+8 rows in set (0.00 sec)
 ```
 
 {{< copyable "sql" >}}
@@ -36,16 +37,16 @@ SELECT * FROM `ANALYZE_STATUS`;
 ```
 
 ```sql
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
-| TABLE_SCHEMA | TABLE_NAME | PARTITION_NAME | JOB_INFO          | PROCESSED_ROWS | START_TIME          | STATE    |
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
-| test         | t          |                | analyze index idx | 2              | 2019-06-21 19:51:14 | finished |
-| test         | t          |                | analyze columns   | 2              | 2019-06-21 19:51:14 | finished |
-| test         | t1         | p0             | analyze columns   | 0              | 2019-06-21 19:51:15 | finished |
-| test         | t1         | p3             | analyze columns   | 0              | 2019-06-21 19:51:15 | finished |
-| test         | t1         | p1             | analyze columns   | 0              | 2019-06-21 19:51:15 | finished |
-| test         | t1         | p2             | analyze columns   | 1              | 2019-06-21 19:51:15 | finished |
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
+| TABLE_SCHEMA | TABLE_NAME | PARTITION_NAME | JOB_INFO          | PROCESSED_ROWS | START_TIME          | END_TIME            | STATE    |
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
+| test         | t          |                | analyze index idx | 2              | 2019-06-21 19:51:14 | 2019-06-21 19:51:14 | finished |
+| test         | t          |                | analyze columns   | 2              | 2019-06-21 19:51:14 | 2019-06-21 19:51:15 | finished |
+| test         | t1         | p0             | analyze columns   | 0              | 2019-06-21 19:51:15 | 2019-06-21 19:51:15 | finished |
+| test         | t1         | p3             | analyze columns   | 0              | 2019-06-21 19:51:15 | 2019-06-21 19:51:16 | finished |
+| test         | t1         | p1             | analyze columns   | 0              | 2019-06-21 19:51:15 | 2019-06-21 19:51:16 | finished |
+| test         | t1         | p2             | analyze columns   | 1              | 2019-06-21 19:51:15 | 2019-06-21 19:51:16 | finished |
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
 6 rows in set
 ```
 

--- a/sql-statements/sql-statement-show-analyze-status.md
+++ b/sql-statements/sql-statement-show-analyze-status.md
@@ -29,18 +29,18 @@ show analyze status;
 ```
 
 ```sql
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
-| Table_schema | Table_name | Partition_name | Job_info          | Processed_rows | Start_time          | State    |
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
-| test         | t          | p1             | analyze columns   |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p0             | analyze columns   |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p0             | analyze index idx |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p1             | analyze index idx |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p2             | analyze index idx |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p3             | analyze index idx |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p3             | analyze columns   |              0 | 2020-05-25 17:23:55 | finished |
-| test         | t          | p2             | analyze columns   |              0 | 2020-05-25 17:23:55 | finished |
-+--------------+------------+----------------+-------------------+----------------+---------------------+----------+
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
+| TABLE_SCHEMA | TABLE_NAME | PARTITION_NAME | JOB_INFO          | PROCESSED_ROWS | START_TIME          | END_TIME            | STATE    |
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
+| test         | t          | p1             | analyze columns   |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p0             | analyze columns   |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p0             | analyze index idx |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p1             | analyze index idx |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p2             | analyze index idx |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p3             | analyze index idx |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p3             | analyze columns   |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
+| test         | t          | p2             | analyze columns   |              0 | 2020-05-25 17:23:55 | 2020-05-25 17:23:55 | finished |
++--------------+------------+----------------+-------------------+----------------+---------------------+---------------------+----------+
 8 rows in set (0.00 sec)
 ```
 


### PR DESCRIPTION
### What is changed, added or deleted? 

Add `END_TIME` field for table `ANALYZE_STATUS` which refer to https://github.com/pingcap/tidb/pull/23674

### Which TiDB version(s) do your changes apply to?


- [x] master (the latest development version)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- https://github.com/pingcap/tidb/pull/23674
- [information-schema-analyze-status](https://docs.pingcap.com/tidb/stable/information-schema-analyze-status)
- [sql-statement-show-analyze-status](https://docs.pingcap.com/tidb/stable/sql-statement-show-analyze-status)
