### PR TITLE
correct a tikv config name

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -271,7 +271,7 @@ Coprocessor 线程池中线程的栈大小，默认值：10，单位：KiB|MiB|G
 + 注意：TTL 暂时只适用于 RawKV 接口。由于所涉及底层数据格式的不同，用户只能在新建集群时设置好该功能，在已有集群上修改该项配置会使得启动报错。
 + 默认值：false
 
-### `ttl-poll-check-interval` <span class="version-mark">从 v5.0 GA 版本开始引入</span>
+### `ttl-check-poll-interval` <span class="version-mark">从 v5.0 GA 版本开始引入</span>
 
 + 回收数据物理空间的检查周期。如果数据超过了 TTL 时间，数据的物理空间会在检查时被强制回收。
 + 默认值：12h


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
ttl-poll-check-interval -> ttl-check-poll-interval
`
mysql> show config;    
| tikv | 10.186.1.1:20160 | storage.ttl-check-poll-interval                                      | 12h
`
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)


