### PR TITLE
check-before-deployment: add info about chronyd/chronyc on CentOS 8

### DIFF
--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -177,7 +177,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
-   - 若返回 `Unit ntpd.service could not be found.` 的报错信息，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来执行与 NTP 的时钟同步：
+   - 若返回 `Unit ntpd.service could not be found.` 的报错信息，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来与 NTP 的时钟同步：
 
         {{< copyable "shell-regular" >}}
 
@@ -229,7 +229,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
 
     > **注意：**
     >
-    > 本步骤仅适用于使用 Chrony 而不是 NTPd 的系统.
+    > 该操作仅适用于使用 Chrony 而不是 ntpd 的系统.
 
     {{< copyable "shell-regular" >}}
 
@@ -255,13 +255,13 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Leap status     : Normal
         ```
 
-    - 如果该命令返回以下结果，则表示同步过程出错：
+    - 如果该命令返回结果如下，则表示同步过程出错：
 
         ```
         Leap status    : Not synchronised
         ```
 
-    - 如果该命令返回以下结果，则表示 `chronyd` 服务未正常运行：
+    - 如果该命令返回结果如下，则表示 `chronyd` 服务未正常运行：
 
         ```
         506 Cannot talk to daemon

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -177,7 +177,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
-   - 若返回 `Unit ntpd.service could not be found.` 的报错信息，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来与 NTP 的时钟同步：
+   - 若返回报错信息 `Unit ntpd.service could not be found.`，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来与 NTP 的时钟同步：
 
         {{< copyable "shell-regular" >}}
 
@@ -191,7 +191,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
         ```
 
-        如果你使用 `chronyd` 的系统配置，请继续执行步骤 3。
+        如果你使用的系统配置是 `chronyd`，请继续执行步骤 3。
 
 2. 执行 `ntpstat` 命令检测是否与 NTP 服务器同步：
 

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -229,7 +229,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
 
     > **注意：**
     >
-    > 该操作仅适用于使用 Chrony 而不是 ntpd 的系统.
+    > 该操作仅适用于使用 Chrony 而不是 ntpd 的系统。
 
     {{< copyable "shell-regular" >}}
 
@@ -237,7 +237,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     chronyc tracking
     ```
 
-    - 如果该命令返回 `Leap status : Normal`，则代表同步过程正常。
+    - 如果该命令返回结果为 `Leap status : Normal`，则代表同步过程正常。
 
         ```
         Reference ID    : 5EC69F0A (ntp1.time.nl)

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -177,6 +177,22 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
+   - 若返回 `Unit ntpd.service could not be found.`，请尝试以下命令查看你的系统是否配置为使用`chronyd` 而不是 `ntpd` 来执行与 NTP 的时钟同步：
+
+        {{< copyable "shell-regular" >}}
+
+        ```bash
+        sudo systemctl status cronyd.service
+        ```
+
+        ```
+        chronyd.service - NTP client/server
+        Loaded: loaded (/usr/lib/systemd/system/chronyd.service; enabled; vendor preset: enabled)
+        Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
+        ```
+
+        如果您的系统配置为使用 `chronyd`，请继续执行步骤 3。
+
 2. 执行 `ntpstat` 命令检测是否与 NTP 服务器同步：
 
     > **注意：**
@@ -207,6 +223,48 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
 
         ```
         Unable to talk to NTP daemon. Is it running?
+        ```
+
+3. 运行 `chronyc tracking` 命令查看 Chrony 服务是否与 NTP 服务器同步。
+
+    > **注意：**
+    >
+    > 本步骤仅适用于使用 Chrony 而不是 NTPd 的系统.
+
+    {{< copyable "shell-regular" >}}
+
+    ```bash
+    chronyc tracking
+    ```
+
+    - 如果该命令返回 `Leap status : Normal`，则代表同步过程正常。
+
+        ```
+        Reference ID    : 5EC69F0A (ntp1.time.nl)
+        Stratum         : 2
+        Ref time (UTC)  : Thu May 20 15:19:08 2021
+        System time     : 0.000022151 seconds slow of NTP time
+        Last offset     : -0.000041040 seconds
+        RMS offset      : 0.000053422 seconds
+        Frequency       : 2.286 ppm slow
+        Residual freq   : -0.000 ppm
+        Skew            : 0.012 ppm
+        Root delay      : 0.012706812 seconds
+        Root dispersion : 0.000430042 seconds
+        Update interval : 1029.8 seconds
+        Leap status     : Normal
+        ```
+
+    - 如果该命令返回以下结果，则表示同步过程出错：
+
+        ```
+        Leap status    : Not synchronised
+        ```
+
+    - 如果该命令返回以下结果，则表示 `chronyd` 服务未正常运行：
+
+        ```
+        506 Cannot talk to daemon
         ```
 
 如果要使 NTP 服务尽快开始同步，执行以下命令。可以将 `pool.ntp.org` 替换为你的 NTP 服务器：

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -177,7 +177,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
-   - 若返回报错信息 `Unit ntpd.service could not be found.`，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来与 NTP 的时钟同步：
+    - 若返回报错信息 `Unit ntpd.service could not be found.`，请尝试执行以下命令，以查看与 NTP 进行时钟同步所使用的系统配置是 `chronyd` 还是 `ntpd`：
 
         {{< copyable "shell-regular" >}}
 
@@ -191,7 +191,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
         ```
 
-        如果你使用的系统配置是 `chronyd`，请继续执行步骤 3。
+        如果你使用的系统配置是 `chronyd`，请直接执行以下的步骤 3。
 
 2. 执行 `ntpstat` 命令检测是否与 NTP 服务器同步：
 
@@ -225,11 +225,11 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Unable to talk to NTP daemon. Is it running?
         ```
 
-3. 运行 `chronyc tracking` 命令查看 Chrony 服务是否与 NTP 服务器同步。
+3. 执行 `chronyc tracking` 命令查看 Chrony 服务是否与 NTP 服务器同步。
 
     > **注意：**
     >
-    > 该操作仅适用于使用 Chrony 而不是 ntpd 的系统。
+    > 该操作仅适用于使用 Chrony 的系统，不适用于使用 NTPd 的系统。
 
     {{< copyable "shell-regular" >}}
 
@@ -261,7 +261,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Leap status    : Not synchronised
         ```
 
-    - 如果该命令返回结果如下，则表示 `chronyd` 服务未正常运行：
+    - 如果该命令返回结果如下，则表示 Chrony 服务未正常运行：
 
         ```
         506 Cannot talk to daemon

--- a/check-before-deployment.md
+++ b/check-before-deployment.md
@@ -177,7 +177,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
     Active: active (running) since 一 2017-12-18 13:13:19 CST; 3s ago
     ```
 
-   - 若返回 `Unit ntpd.service could not be found.`，请尝试以下命令查看你的系统是否配置为使用`chronyd` 而不是 `ntpd` 来执行与 NTP 的时钟同步：
+   - 若返回 `Unit ntpd.service could not be found.` 的报错信息，请尝试运行以下命令，查看你是否使用 `chronyd` 而不是 `ntpd` 的系统配置来执行与 NTP 的时钟同步：
 
         {{< copyable "shell-regular" >}}
 
@@ -191,7 +191,7 @@ TiDB 是一套分布式数据库系统，需要节点间保证时间的同步，
         Active: active (running) since Mon 2021-04-05 09:55:29 EDT; 3 days ago
         ```
 
-        如果您的系统配置为使用 `chronyd`，请继续执行步骤 3。
+        如果你使用 `chronyd` 的系统配置，请继续执行步骤 3。
 
 2. 执行 `ntpstat` 命令检测是否与 NTP 服务器同步：
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)
On CentOS 8 Chrony is used by default for NTP services.

- https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/using-chrony-to-configure-ntp#sect-checking_if_chrony_is_synchronized
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/5283
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
