### PR TITLE
Update dumpling-overview.md

### DIFF
--- a/dumpling-overview.md
+++ b/dumpling-overview.md
@@ -187,7 +187,7 @@ Dumpling 同时还支持从 `~/.aws/credentials` 读取凭证文件。更多 Dum
   -P 4000 \
   -h 127.0.0.1 \
   -r 200000 \
-  -o s3://${Bucket}/${Folder} \
+  -o "s3://${Bucket}/${Folder}" \
   --s3.region "${region}"
 ```
 

--- a/dumpling-overview.md
+++ b/dumpling-overview.md
@@ -177,7 +177,7 @@ export AWS_SECRET_ACCESS_KEY=${SecretKey}
 
 Dumpling 同时还支持从 `~/.aws/credentials` 读取凭证文件。更多 Dumpling 存储配置可以参考[外部存储](/br/backup-and-restore-storages.md)。
 
-在进行 Dumpling 备份时，显式指定参数 `--s3.region`，即表示 S3 存储所在的区域。
+在进行 Dumpling 备份时，显式指定参数 `--s3.region`，即表示 S3 存储所在的区域。e.g `ap-northeast-1`。
 
 {{< copyable "shell-regular" >}}
 
@@ -187,7 +187,7 @@ Dumpling 同时还支持从 `~/.aws/credentials` 读取凭证文件。更多 Dum
   -P 4000 \
   -h 127.0.0.1 \
   -r 200000 \
-  -o "s3://${Bucket}/${Folder}" \
+  -o s3://${Bucket}/${Folder} \
   --s3.region "${region}"
 ```
 

--- a/dumpling-overview.md
+++ b/dumpling-overview.md
@@ -177,7 +177,7 @@ export AWS_SECRET_ACCESS_KEY=${SecretKey}
 
 Dumpling 同时还支持从 `~/.aws/credentials` 读取凭证文件。更多 Dumpling 存储配置可以参考[外部存储](/br/backup-and-restore-storages.md)。
 
-在进行 Dumpling 备份时，显式指定参数 `--s3.region`，即表示 S3 存储所在的区域。e.g `ap-northeast-1`。
+在进行 Dumpling 备份时，显式指定参数 `--s3.region`，即表示 S3 存储所在的区域，例如 `ap-northeast-1`。
 
 {{< copyable "shell-regular" >}}
 


### PR DESCRIPTION
The the two change:
--s3.region， it's confusing if we input the region name like Tokyo, it will throw error,
create dumper failed: Bucket <bucketname>is not accessible: MissingEndpoint: 'Endpoint' configuration is required for this service: [BR:ExternalStorage:ErrStorageInvalidConfig]invalid external storage config

-o ,  if the path surround by ", it will throw error,
create dumper failed: parse “s3://s3path“: first path segment in URL cannot contain colon

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
modify the export configuration for s3
added config example for s3.region, remove colon in -o

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
