### PR TITLE
zh.md bot checking /tidcd, fix typo error

### DIFF
--- a/.zhmdyaml
+++ b/.zhmdyaml
@@ -1,0 +1,1 @@
+version: 1

--- a/.zhmdyaml
+++ b/.zhmdyaml
@@ -1,1 +1,0 @@
-version: 1

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -236,7 +236,7 @@ URI 中可配置的的参数如下：
 | `hashingScheme` | 用于选择发送分区的哈希算法（可选 `JavaStringHash` 和 `Murmur3`，默认值为 `JavaStringHash`）|
 | `properties.*` | 在 TiCDC 中 Pulsar producer 上添加用户定义的属性（可选，示例 `properties.location=Hangzhou`）|
 
-更多关于 Pulsar 的参数解释，参见 ["pulsar-client-go ClientOptions 文档"](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ClientOptions) 和 ["pulsar-client-go ProducerOptions 文档"](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ProducerOptions) 。
+更多关于 Pulsar 的参数解释，参见 [“pulsar-client-go ClientOptions 文档”](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ClientOptions) 和 [“pulsar-client-go ProducerOptions 文档”](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ProducerOptions) 。
 
 #### 使用同步任务配置文件
 

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -85,12 +85,12 @@ tiup cluster upgrade <cluster-name> v4.0.6
 
 以上状态流转图中的编号说明如下：
 
-- ① 执行 `changefeed pause` 命令  
-- ② 执行 `changefeed resume` 恢复同步任务  
-- ③ `changefeed` 运行过程中发生可恢复的错误  
-- ④ 执行 `changefeed resume` 恢复同步任务  
-- ⑤ `changefeed` 运行过程中发生不可恢复的错误  
-- ⑥ 同步任务已经进行到预设的 TargetTs，同步自动停止  
+- ① 执行 `changefeed pause` 命令。 
+- ② 执行 `changefeed resume` 恢复同步任务。
+- ③ `changefeed` 运行过程中发生可恢复的错误。
+- ④ 执行 `changefeed resume` 恢复同步任务。
+- ⑤ `changefeed` 运行过程中发生不可恢复的错误。
+- ⑥ 同步任务已经进行到预设的 TargetTs，同步自动停止。
 
 #### 创建同步任务
 
@@ -236,7 +236,7 @@ URI 中可配置的的参数如下：
 | `hashingScheme` | 用于选择发送分区的哈希算法（可选 `JavaStringHash` 和 `Murmur3`，默认值为 `JavaStringHash`）|
 | `properties.*` | 在 TiCDC 中 Pulsar producer 上添加用户定义的属性（可选，示例 `properties.location=Hangzhou`）|
 
-更多关于 Pulsar 的参数解释，参见 [pulsar-client-go ClientOptions 文档](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ClientOptions) 和 [pulsar-client-go ProducerOptions 文档](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ProducerOptions)
+更多关于 Pulsar 的参数解释，参见 ["pulsar-client-go ClientOptions 文档"](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ClientOptions) 和 ["pulsar-client-go ProducerOptions 文档"](https://godoc.org/github.com/apache/pulsar-client-go/pulsar#ProducerOptions) 。
 
 #### 使用同步任务配置文件
 
@@ -280,7 +280,7 @@ cdc cli changefeed list --pd=http://10.0.10.25:2379
     - `stopped`: 停止同步（手动暂停）
     - `error`: 停止同步（出错）
     - `removed`: 已删除任务（只在指定 `--all` 选项时才会显示该状态的任务。未指定时，可通过 `query` 查询该状态的任务）
-    - `finished`: 任务已经同步到指定 `target-ts`，处于已完成状态（只在指定 `--all` 选项时才会显示该状态的任务。未指定时，可通过 `query` 查询该状态的任务）
+    - `finished`: 任务已经同步到指定 `target-ts`，处于已完成状态（只在指定 `--all` 选项时才会显示该状态的任务。未指定时，可通过 `query` 查询该状态的任务）。
 
 #### 查询特定同步任务
 
@@ -764,7 +764,7 @@ sync-ddl = true
     + 多个集群的 TiCDC 组件构成一个单向 DDL 同步链，不能成环。例如以上在 TiDB 集群 A，B 和 C 上创建环形同步任务的示例中，只有 C 集群的 TiCDC 组件关闭了 `sync-ddl`。
     + DDL 语句必须在单向 DDL 同步链的开始集群上执行，例如示例中的 A 集群。
 
-## 输出行变更的历史值 <span class="version-mark">从 v4.0.5 版本开始引入</span>
+## 输出行变更的历史值<span class="version-mark">从 v4.0.5 版本开始引入</span>
 
 > **警告：**
 >

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -764,7 +764,7 @@ sync-ddl = true
     + 多个集群的 TiCDC 组件构成一个单向 DDL 同步链，不能成环。例如以上在 TiDB 集群 A，B 和 C 上创建环形同步任务的示例中，只有 C 集群的 TiCDC 组件关闭了 `sync-ddl`。
     + DDL 语句必须在单向 DDL 同步链的开始集群上执行，例如示例中的 A 集群。
 
-## 输出行变更的历史值 <span class="version-mark">从 v4.0.5 版本开始引入</span>
+## 输出行变更的历史值<span class="version-mark">从 v4.0.5 版本开始引入</span>
 
 > **警告：**
 >

--- a/ticdc/manage-ticdc.md
+++ b/ticdc/manage-ticdc.md
@@ -764,7 +764,7 @@ sync-ddl = true
     + 多个集群的 TiCDC 组件构成一个单向 DDL 同步链，不能成环。例如以上在 TiDB 集群 A，B 和 C 上创建环形同步任务的示例中，只有 C 集群的 TiCDC 组件关闭了 `sync-ddl`。
     + DDL 语句必须在单向 DDL 同步链的开始集群上执行，例如示例中的 A 集群。
 
-## 输出行变更的历史值<span class="version-mark">从 v4.0.5 版本开始引入</span>
+## 输出行变更的历史值 <span class="version-mark">从 v4.0.5 版本开始引入</span>
 
 > **警告：**
 >

--- a/ticdc/monitor-ticdc.md
+++ b/ticdc/monitor-ticdc.md
@@ -51,21 +51,21 @@ cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="mysql://root:1
 
 **Changefeed** 面板的各指标说明如下：
 
-- Changefeed table count：一个同步任务中分配到各个 TiCDC 节点同步的数据表个数
-- Processor resolved ts：TiCDC 节点内部状态中已同步的时间点
-- Table resolved ts：同步任务中各数据表的同步进度
-- Changefeed checkpoint：同步任务同步到下游的进度，正常情况下绿柱应和黄线相接
-- PD etcd requests/s：TiCDC 节点每秒向 PD 读写数据的次数
-- Exit error count：每分钟内导致同步中断的错误发生次数
-- Changefeed checkpoint lag：同步任务上下游数据的进度差（以时间计算）
-- Changefeed resolved ts lag：TiCDC 节点内部同步状态与上游的进度差（以时间计算）
-- Flush sink duration：TiCDC 异步刷写数据入下游的耗时直方图
-- Flush sink duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，TiCDC 异步刷写数据入下游所花费的时间
-- Sink write duration：TiCDC 将一个事务的更改写到下游的耗时直方图
-- Sink write duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，TiCDC 将一个事务的更改写到下游所花费的时间
-- MySQL sink conflict detect duration：MySQL 写入冲突检测耗时直方图
-- MySQL sink conflict detect duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，MySQL 写入冲突检测耗时
-- MySQL sink worker load：TiCDC 节点中写 MySQL 线程的负载情况
+- Changefeed table count：一个同步任务中分配到各个 TiCDC 节点同步的数据表个数。
+- Processor resolved ts：TiCDC 节点内部状态中已同步的时间点。
+- Table resolved ts：同步任务中各数据表的同步进度。
+- Changefeed checkpoint：同步任务同步到下游的进度，正常情况下绿柱应和黄线相接。
+- PD etcd requests/s：TiCDC 节点每秒向 PD 读写数据的次数。
+- Exit error count：每分钟内导致同步中断的错误发生次数。
+- Changefeed checkpoint lag：同步任务上下游数据的进度差（以时间计算）。
+- Changefeed resolved ts lag：TiCDC 节点内部同步状态与上游的进度差（以时间计算）。
+- Flush sink duration：TiCDC 异步刷写数据入下游的耗时直方图。
+- Flush sink duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，TiCDC 异步刷写数据入下游所花费的时间。
+- Sink write duration：TiCDC 将一个事务的更改写到下游的耗时直方图。
+- Sink write duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，TiCDC 将一个事务的更改写到下游所花费的时间。
+- MySQL sink conflict detect duration：MySQL 写入冲突检测耗时直方图。
+- MySQL sink conflict detect duration percentile：每秒钟中 95%、99% 和 99.9% 的情况下，MySQL 写入冲突检测耗时。
+- MySQL sink worker load：TiCDC 节点中写 MySQL 线程的负载情况。
 
 ## Events 面板
 
@@ -77,25 +77,25 @@ cdc cli changefeed create --pd=http://10.0.10.25:2379 --sink-uri="mysql://root:1
 
 **Events** 面板的各指标说明如下：
 
-- Eventfeed count：TiCDC 节点中 Eventfeed RPC 的个数
-- Event size percentile：每秒钟中 95% 和 99.9% 的情况下，TiCDC 收到的来自 TiKV 的数据变更消息大小
-- Eventfeed error/m：TiCDC 节点中每分钟 Eventfeed RPC 遇到的错误个数
-- KV client receive events/s：TiCDC 节点中 KV client 模块每秒收到来自 TiKV 的数据变更个数
-- Puller receive events/s：TiCDC 节点中 Puller 模块每秒收到来自 KV client 模块的数据变更个数
-- Puller output events/s：TiCDC 节点中 Puller 模块每秒输出到 Sorter 模块的数据变更个数
-- Sink flush rows/s：TiCDC 节点每秒写到下游的数据变更的个数
-- Puller buffer size：TiCDC 节点中缓存在 Puller 模块中的数据变更个数
-- Entry sorter buffer size：TiCDC 节点中缓存在 Sorter 模块中的数据变更个数
-- Processor/Mounter buffer size：TiCDC 节点中缓存在 Processor 模块和 Mounter 模块中的数据变更个数
-- Sink row buffer size：TiCDC 节点中缓存在 Sink 模块中的数据变更个数
-- Entry sorter sort duration：TiCDC 节点对数据变更进行排序的耗时直方图
-- Entry sorter sort duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 排序数据变更所花费的时间
-- Entry sorter merge duration：TiCDC 节点合并排序后的数据变更的耗时直方图
-- Entry sorter merge duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 合并排序后的数据变更所花费的时间
-- Mounter unmarshal duration：TiCDC 节点解码数据变更的耗时直方图
-- Mounter unmarshal duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 解码数据变更所花费的时间
-- KV client dispatch events/s：TiCDC 节点内部 KV client 模块每秒分发数据变更的个数
-- KV client batch resolved size：TiKV 批量发给 TiCDC 的 resolved ts 消息的大小
+- Eventfeed count：TiCDC 节点中 Eventfeed RPC 的个数。
+- Event size percentile：每秒钟中 95% 和 99.9% 的情况下，TiCDC 收到的来自 TiKV 的数据变更消息大小。
+- Eventfeed error/m：TiCDC 节点中每分钟 Eventfeed RPC 遇到的错误个数。
+- KV client receive events/s：TiCDC 节点中 KV client 模块每秒收到来自 TiKV 的数据变更个数。
+- Puller receive events/s：TiCDC 节点中 Puller 模块每秒收到来自 KV client 模块的数据变更个数。
+- Puller output events/s：TiCDC 节点中 Puller 模块每秒输出到 Sorter 模块的数据变更个数。
+- Sink flush rows/s：TiCDC 节点每秒写到下游的数据变更的个数。
+- Puller buffer size：TiCDC 节点中缓存在 Puller 模块中的数据变更个数。
+- Entry sorter buffer size：TiCDC 节点中缓存在 Sorter 模块中的数据变更个数。
+- Processor/Mounter buffer size：TiCDC 节点中缓存在 Processor 模块和 Mounter 模块中的数据变更个数。
+- Sink row buffer size：TiCDC 节点中缓存在 Sink 模块中的数据变更个数。
+- Entry sorter sort duration：TiCDC 节点对数据变更进行排序的耗时直方图。
+- Entry sorter sort duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 排序数据变更所花费的时间。
+- Entry sorter merge duration：TiCDC 节点合并排序后的数据变更的耗时直方图。
+- Entry sorter merge duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 合并排序后的数据变更所花费的时间。
+- Mounter unmarshal duration：TiCDC 节点解码数据变更的耗时直方图。
+- Mounter unmarshal duration percentile：每秒钟中 95%，99% 和 99.9% 的情况下，TiCDC 解码数据变更所花费的时间。
+- KV client dispatch events/s：TiCDC 节点内部 KV client 模块每秒分发数据变更的个数。
+- KV client batch resolved size：TiKV 批量发给 TiCDC 的 resolved ts 消息的大小。
 
 ## TiKV 面板
 

--- a/ticdc/ticdc-overview.md
+++ b/ticdc/ticdc-overview.md
@@ -82,7 +82,7 @@ TiCDC 从 4.0.8 版本开始，可通过修改任务配置来同步**没有有�
 
 - 暂不支持单独使用 RawKV 的 TiKV 集群。
 - 暂不支持在 TiDB 中[创建 SEQUENCE 的 DDL 操作](/sql-statements/sql-statement-create-sequence.md)和 [SEQUENCE 函数](/sql-statements/sql-statement-create-sequence.md#sequence-函数)。在上游 TiDB 使用 SEQUENCE 时，TiCDC 将会忽略掉上游执行的 SEQUENCE DDL 操作/函数，但是使用 SEQUENCE 函数的 DML 操作可以正确地同步。
-- 对上游存在较大事务的场景提供部分支持，详见 [TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)。
+- 对上游存在较大事务的场景提供部分支持，详见 [TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)
 
 ## 兼容性问题提示
 

--- a/ticdc/ticdc-overview.md
+++ b/ticdc/ticdc-overview.md
@@ -82,7 +82,7 @@ TiCDC 从 4.0.8 版本开始，可通过修改任务配置来同步**没有有�
 
 - 暂不支持单独使用 RawKV 的 TiKV 集群。
 - 暂不支持在 TiDB 中[创建 SEQUENCE 的 DDL 操作](/sql-statements/sql-statement-create-sequence.md)和 [SEQUENCE 函数](/sql-statements/sql-statement-create-sequence.md#sequence-函数)。在上游 TiDB 使用 SEQUENCE 时，TiCDC 将会忽略掉上游执行的 SEQUENCE DDL 操作/函数，但是使用 SEQUENCE 函数的 DML 操作可以正确地同步。
-- 对上游存在较大事务的场景提供部分支持，详见（[FAQ：TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)）。
+- 对上游存在较大事务的场景提供部分支持，详见 [TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)。
 
 ## 兼容性问题提示
 

--- a/ticdc/ticdc-overview.md
+++ b/ticdc/ticdc-overview.md
@@ -81,8 +81,8 @@ TiCDC 从 4.0.8 版本开始，可通过修改任务配置来同步**没有有�
 目前 TiCDC 暂不支持的场景如下：
 
 - 暂不支持单独使用 RawKV 的 TiKV 集群。
-- 暂不支持在 TiDB 中[创建 SEQUENCE 的 DDL 操作](/sql-statements/sql-statement-create-sequence.md) 和 [SEQUENCE 函数](/sql-statements/sql-statement-create-sequence.md#sequence-函数)。在上游 TiDB 使用 SEQUENCE 时，TiCDC 将会忽略掉上游执行的 SEQUENCE DDL 操作/函数，但是使用 SEQUENCE 函数的 DML 操作可以正确地同步。
-- 对上游存在较大事务的场景提供部分支持，详见：[FAQ：TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)。
+- 暂不支持在 TiDB 中[创建 SEQUENCE 的 DDL 操作](/sql-statements/sql-statement-create-sequence.md)和 [SEQUENCE 函数](/sql-statements/sql-statement-create-sequence.md#sequence-函数)。在上游 TiDB 使用 SEQUENCE 时，TiCDC 将会忽略掉上游执行的 SEQUENCE DDL 操作/函数，但是使用 SEQUENCE 函数的 DML 操作可以正确地同步。
+- 对上游存在较大事务的场景提供部分支持，详见（[FAQ：TiCDC 是否支持同步大事务？有什么风险吗？](/ticdc/troubleshoot-ticdc.md#ticdc-支持同步大事务吗有什么风险吗)）。
 
 ## 兼容性问题提示
 
@@ -93,7 +93,9 @@ TiCDC 从 4.0.8 版本开始，可通过修改任务配置来同步**没有有�
 - 若 TiCDC 集群版本为 v4.0.8 或以下，使用 v5.0.0-rc 版本的 `cdc cli` 创建同步任务 changefeed 时，可能导致 TiCDC 集群陷入异常状态，导致同步卡住。
 - 若 TiCDC 集群版本为 v4.0.9 或以上，使用 v5.0.0-rc 版本的 `cdc cli` 创建同步任务 changefeed，会导致 Old Value 和 Unified Sorter 特性被非预期地默认开启。
 
-处理方案：使用和 TiCDC 集群版本对应的 `cdc` 可执行文件进行如下操作：
+处理方案：
+
+  使用和 TiCDC 集群版本对应的 `cdc` 可执行文件进行如下操作：
 
 1. 删除使用 v5.0.0-rc 版本创建的 changefeed，例如：`tiup cdc:v4.0.9 cli changefeed remove -c xxxx --pd=xxxxx --force`。
 2. 如果 TiCDC 同步已经卡住，重启 TiCDC 集群，例如：`tiup cluster restart <cluster_name> -R cdc`。

--- a/ticdc/ticdc-overview.md
+++ b/ticdc/ticdc-overview.md
@@ -95,7 +95,7 @@ TiCDC 从 4.0.8 版本开始，可通过修改任务配置来同步**没有有�
 
 处理方案：
 
-  使用和 TiCDC 集群版本对应的 `cdc` 可执行文件进行如下操作：
+使用和 TiCDC 集群版本对应的 `cdc` 可执行文件进行如下操作：
 
 1. 删除使用 v5.0.0-rc 版本创建的 changefeed，例如：`tiup cdc:v4.0.9 cli changefeed remove -c xxxx --pd=xxxxx --force`。
 2. 如果 TiCDC 同步已经卡住，重启 TiCDC 集群，例如：`tiup cluster restart <cluster_name> -R cdc`。

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -316,7 +316,7 @@ TiCDC 对大事务（大小超过 5 GB）提供部分支持，根据场景不同
 4. 修改 changefeed 配置，将上述 `start-ts` 添加到 `ignore-txn-start-ts` 配置项中。
 5. 恢复被暂停的 changefeed。
 
-## TiCDC 集群升级到 v4.0.8 之后，changefeed 报错 `[CDC:ErrKafkaInvalidConfig]Canal requires old value to be enabled`。
+## TiCDC 集群升级到 v4.0.8 之后，changefeed 报错 `[CDC:ErrKafkaInvalidConfig]Canal requires old value to be enabled`，为什么？
 
 自 v4.0.8 起，如果 changefeed 使用 canal 或者 maxwell 协议输出，TiCDC 会自动开启 Old Value 功能。但如果 TiCDC 是从较旧版本升级到 v4.0.8 或以上版本的，changefeed 使用 canal 或 maxwell 协议的同时 Old Value 功能被禁用，此时会出现该报错。可以按照以下步骤解决该报错：
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -275,7 +275,7 @@ Open protocol 的输出中 type = 6 即为 null，比如：
 
 更多信息请参考 [Open protocol Event 格式定义](/ticdc/ticdc-open-protocol.md#column-的类型码)。
 
-## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]` 。
+## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]` ，怎么办？
 
 自 v4.0.9 起可以尝试开启 unified sorter 特性进行同步；或者使用 BR 工具进行一次增量备份和恢复，然后从新的时间点开启 TiCDC 同步任务。TiCDC 将会在后续版本中对该问题进行优化。
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -228,7 +228,7 @@ cdc cli changefeed query --pd=http://10.0.10.25:2379 --changefeed-id 28c43ffc-23
 
 ## 为什么 TiCDC 到 Kafka 的同步任务延时越来越大？
 
-* 请参考 [如何查看 TiCDC 同步任务的状态？](/ticdc/troubleshoot-ticdc.md#如何查看-ticdc-同步任务的状态) 检查下同步任务的状态是否正常。
+* 请参考[如何查看 TiCDC 同步任务的状态？](/ticdc/troubleshoot-ticdc.md#如何查看-ticdc-同步任务的状态) 检查下同步任务的状态是否正常。
 * 请适当调整 Kafka 的以下参数：
     * `message.max.bytes`，将 Kafka 的 `server.properties` 中该参数调大到 `1073741824` (1 GB)。
     * `replica.fetch.max.bytes`，将 Kafka 的 `server.properties` 中该参数调大到 `1073741824` (1 GB)。
@@ -240,7 +240,7 @@ cdc cli changefeed query --pd=http://10.0.10.25:2379 --changefeed-id 28c43ffc-23
 
 ## TiCDC 把数据同步到 Kafka 时，能在 TiDB 中控制单条消息大小的上限吗？
 
-可以通过 `max-message-bytes` 控制每次向 Kafka broker 发送消息的最大数据量（可选，默认值 64MB）；通过 `max-batch-size` 参数指定每条 kafka 消息中变更记录的最大数量，目前仅对 Kafka 的 protocol 为 `default` 时有效（可选，默认值为 `4096`）;
+可以通过 `max-message-bytes` 控制每次向 Kafka broker 发送消息的最大数据量（可选，默认值 64MB）；通过 `max-batch-size` 参数指定每条 kafka 消息中变更记录的最大数量，目前仅对 Kafka 的 protocol 为 `default` 时有效（可选，默认值为 `4096`）。
 
 ## TiCDC 把数据同步到 Kafka 时，一条消息中会不会包含多种数据变更？
 
@@ -275,7 +275,7 @@ Open protocol 的输出中 type = 6 即为 null，比如：
 
 更多信息请参考 [Open protocol Event 格式定义](/ticdc/ticdc-open-protocol.md#column-的类型码)。
 
-## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]`
+## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]` 。
 
 自 v4.0.9 起可以尝试开启 unified sorter 特性进行同步；或者使用 BR 工具进行一次增量备份和恢复，然后从新的时间点开启 TiCDC 同步任务。TiCDC 将会在后续版本中对该问题进行优化。
 
@@ -316,7 +316,7 @@ TiCDC 对大事务（大小超过 5 GB）提供部分支持，根据场景不同
 4. 修改 changefeed 配置，将上述 `start-ts` 添加到 `ignore-txn-start-ts` 配置项中。
 5. 恢复被暂停的 changefeed。
 
-## TiCDC 集群升级到 v4.0.8 之后，changefeed 报错 `[CDC:ErrKafkaInvalidConfig]Canal requires old value to be enabled`
+## TiCDC 集群升级到 v4.0.8 之后，changefeed 报错 `[CDC:ErrKafkaInvalidConfig]Canal requires old value to be enabled`。
 
 自 v4.0.8 起，如果 changefeed 使用 canal 或者 maxwell 协议输出，TiCDC 会自动开启 Old Value 功能。但如果 TiCDC 是从较旧版本升级到 v4.0.8 或以上版本的，changefeed 使用 canal 或 maxwell 协议的同时 Old Value 功能被禁用，此时会出现该报错。可以按照以下步骤解决该报错：
 
@@ -351,11 +351,11 @@ TiCDC 对大事务（大小超过 5 GB）提供部分支持，根据场景不同
 
 如果 `pd-ctl service-gc-safepoint --pd <pd-addrs>` 的结果中没有 `gc_worker service_id`：
 
-+ 如果 PD 的版本 <= v4.0.8，详见 [PD issue #3128](https://github.com/tikv/pd/issues/3128)
-+ 如果 PD 是由 v4.0.8 或更低版本滚动升级到新版，详见 [PD issue #3366](https://github.com/tikv/pd/issues/3366)
++ 如果 PD 的版本 <= v4.0.8，详见 [PD issue #3128](https://github.com/tikv/pd/issues/3128)。
++ 如果 PD 是由 v4.0.8 或更低版本滚动升级到新版，详见 [PD issue #3366](https://github.com/tikv/pd/issues/3366)。
 + 对于其他情况，请将上述命令执行结果反馈到 [AskTUG 论坛](https://asktug.com/tags/ticdc)。
 
-## 使用 TiCDC 创建同步任务时将 `enable-old-value` 设置为 `true` 后，上游的 `INSERT`/`UPDATE` 语句经 TiCDC 同步到下游后变为 `REPLACE INTO`
+## 使用 TiCDC 创建同步任务时将 `enable-old-value` 设置为 `true` 后，上游的 `INSERT`/`UPDATE` 语句经 TiCDC 同步到下游后变为 `REPLACE INTO`。
 
 TiCDC 创建 changefeed 时会默认指定 `safe-mode` 为 `true`，从而为上游的 `INSERT`/`UPDATE` 语句生成 `REPLACE INTO` 的执行语句。
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -275,7 +275,7 @@ Open protocol 的输出中 type = 6 即为 null，比如：
 
 更多信息请参考 [Open protocol Event 格式定义](/ticdc/ticdc-open-protocol.md#column-的类型码)。
 
-## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]` ，怎么办？
+## TiCDC 启动任务的 start-ts 时间戳与当前时间差距较大，任务执行过程中同步中断，出现错误 `[CDC:ErrBufferReachLimit]`，怎么办？
 
 自 v4.0.9 起可以尝试开启 unified sorter 特性进行同步；或者使用 BR 工具进行一次增量备份和恢复，然后从新的时间点开启 TiCDC 同步任务。TiCDC 将会在后续版本中对该问题进行优化。
 

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -228,7 +228,7 @@ cdc cli changefeed query --pd=http://10.0.10.25:2379 --changefeed-id 28c43ffc-23
 
 ## 为什么 TiCDC 到 Kafka 的同步任务延时越来越大？
 
-* 请参考[如何查看 TiCDC 同步任务的状态？](/ticdc/troubleshoot-ticdc.md#如何查看-ticdc-同步任务的状态) 检查下同步任务的状态是否正常。
+* 请参考[如何查看 TiCDC 同步任务的状态？](/ticdc/troubleshoot-ticdc.md#如何查看-ticdc-同步任务的状态)检查下同步任务的状态是否正常。
 * 请适当调整 Kafka 的以下参数：
     * `message.max.bytes`，将 Kafka 的 `server.properties` 中该参数调大到 `1073741824` (1 GB)。
     * `replica.fetch.max.bytes`，将 Kafka 的 `server.properties` 中该参数调大到 `1073741824` (1 GB)。

--- a/ticdc/troubleshoot-ticdc.md
+++ b/ticdc/troubleshoot-ticdc.md
@@ -355,7 +355,7 @@ TiCDC 对大事务（大小超过 5 GB）提供部分支持，根据场景不同
 + 如果 PD 是由 v4.0.8 或更低版本滚动升级到新版，详见 [PD issue #3366](https://github.com/tikv/pd/issues/3366)。
 + 对于其他情况，请将上述命令执行结果反馈到 [AskTUG 论坛](https://asktug.com/tags/ticdc)。
 
-## 使用 TiCDC 创建同步任务时将 `enable-old-value` 设置为 `true` 后，上游的 `INSERT`/`UPDATE` 语句经 TiCDC 同步到下游后变为 `REPLACE INTO`。
+## 使用 TiCDC 创建同步任务时将 `enable-old-value` 设置为 `true` 后，为什么上游的 `INSERT`/`UPDATE` 语句经 TiCDC 同步到下游后变为了 `REPLACE INTO`？
 
 TiCDC 创建 changefeed 时会默认指定 `safe-mode` 为 `true`，从而为上游的 `INSERT`/`UPDATE` 语句生成 `REPLACE INTO` 的执行语句。
 


### PR DESCRIPTION
```
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/deploy-ticdc.md: no issues found
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/integrate-confluent-using-ticdc.md: no issues found
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/manage-ticdc.md
  239:132  warning  shouldn't spaces between Chinese characters  ZH425
   767:13  warning  shouldn't spaces between Chinese characters  ZH425

⚠ 2 warnings
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/monitor-ticdc.md: no issues found
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/ticdc-glossary.md: no issues found
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/ticdc-open-protocol.md: no issues found
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/ticdc-overview.md
       84:87  warning  shouldn't spaces between Chinese characters        ZH425
  85:3-85:46  warning  sentence colon'：' count:2, bigger than limit:1    ZH403
      85:105  error    shouldn't use full-width char:'。' in en sentence  ZH417
  96:1-96:42  warning  sentence colon'：' count:2, bigger than limit:1    ZH403

4 messages (✖ 1 error, ⚠ 3 warnings)
/Users/wph95/hackathon/2021/base_docs/docs-cn/ticdc/troubleshoot-ticdc.md
    231:6  warning  shouldn't spaces between Chinese characters       ZH425
  243:168  error    shouldn't use half-width char:';' in cn sentence  ZH418

2 messages (✖ 1 error, ⚠ 1 warning)

Process finished with exit code 0
```