### PR TITLE
 TiKV configuration: update max-peer-down-duration default value

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -521,7 +521,7 @@ raftstore 相关的配置项。
 
 + 副本允许的最长未响应时间，超过将被标记为 down，后续 PD 会尝试将其删掉。
 + 默认值：10m
-+ 最小值：当 hibernate-regions 打开时为 peer-stale-check-interval * 2，否则为 0。
++ 最小值：当 Hibernate Region 功能启用时，为 peer-stale-check-interval * 2；Hibernate Region 功能关闭时，为 0。
 
 ### `max-leader-missing-duration`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -520,8 +520,8 @@ raftstore 相关的配置项。
 ### `max-peer-down-duration`
 
 + 副本允许的最长未响应时间，超过将被标记为 down，后续 PD 会尝试将其删掉。
-+ 默认值：5m
-+ 最小值：0
++ 默认值：10m
++ 最小值：当 hibernate-regions 打开时为 peer-stale-check-interval * 2，否则为 0。
 
 ### `max-leader-missing-duration`
 


### PR DESCRIPTION
Signed-off-by: Yi Wu <yiwu@pingcap.com>

### What is changed, added or deleted? (Required)

TiKV max-peer-down-duration default value had changed after https://github.com/tikv/tikv/pull/10459. Update docs.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
