### PR TITLE
system-variables: add datadir and license

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -91,7 +91,7 @@ mysql> SELECT * FROM t1;
 - 作用域：NONE
 - 默认值：/tmp/tidb
 - 这个变量表示数据存储的位置。如果数据存储在 TiKV 上，位置可以是本地路径或指向 PD 服务器的路径。
-- 格式为 `ip_address:port` 表示 TiDB 在启动时连接到的 PD 服务器。
+- 如果变量值的格式为 `ip_address:port`，表示 TiDB 在启动时连接到的 PD 服务器。
 
 ### `ddl_slow_threshold`
 
@@ -145,7 +145,7 @@ mysql> SELECT * FROM t1;
 
 - 作用域：NONE
 - 默认值：Apache License 2.0
-- 这个变量表示 TiDB 服务器安装的许可证。
+- 这个变量表示 TiDB 服务器的安装许可证。
 
 ### `max_execution_time`
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -90,7 +90,7 @@ mysql> SELECT * FROM t1;
 
 - 作用域：NONE
 - 默认值：/tmp/tidb
-- 这个变量表示数据存储的位置。如果数据存储在 TiKV 上，位置可以是本地路径或指向 PD 服务器的路径。
+- 这个变量表示数据存储的位置，位置可以是本地路径。如果数据存储在 TiKV 上，则可以是指向 PD 服务器的路径。
 - 如果变量值的格式为 `ip_address:port`，表示 TiDB 在启动时连接到的 PD 服务器。
 
 ### `ddl_slow_threshold`

--- a/system-variables.md
+++ b/system-variables.md
@@ -86,6 +86,13 @@ mysql> SELECT * FROM t1;
 - 默认值：1000
 - 这个变量用于控制公共表表达式的最大递归深度。
 
+### datadir
+
+- 作用域：NONE
+- 默认值：/tmp/tidb
+- 这个变量表示数据存储的位置。如果数据存储在 TiKV 上，位置可以是本地路径或指向 PD 服务器的路径。
+- 格式为 `ip_address:port` 表示 TiDB 在启动时连接到的 PD 服务器。
+
 ### `ddl_slow_threshold`
 
 - 作用域：INSTANCE
@@ -133,6 +140,12 @@ mysql> SELECT * FROM t1;
 - 作用域：SESSION
 - 默认值：0
 - 这个变量用来显示上一个 `execute` 语句所使用的执行计划是不是直接从 plan cache 中取出来的。
+
+### license
+
+- 作用域：NONE
+- 默认值：Apache License 2.0
+- 这个变量表示 TiDB 服务器安装的许可证。
 
 ### `max_execution_time`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
This adds 2 missing system variables that function correctly in TiDB: datadir and license.

The language is intentionally a little vague and says "typically" because in mocktikv/unistore cases it will show a path, but that is for developers to know. I don't believe we ever change the license string for enterprise edition but the language doesn't preclude that.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/5761
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
