### PR TITLE
tiup: add notice about importing cluster that don't have all nodes mo…

### DIFF
--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -17,7 +17,7 @@ title: tiup cluster import
 >     + 启用了 TiDB Lightning/ Importer 的集群
 >     + 仍使用老版本 `push` 的方式收集监控指标（从 v3.0 起默认为 `pull` 模式，如果没有特意调整过则可以支持）
 >     + 在 `inventory.ini` 配置文件中单独为机器的 `node_exporter` / `blackbox_exporter` 通过 `node_exporter_port`/`blackbox_exporter_port` 设置了非默认端口（在 `group_vars` 目录中统一配置的可以兼容）
-> + 如果使用 TiDB Ansible 部署的集群中有部分节点未部署监控，应当先使用 TiDB Ansible 在 inventory 的 `monitored_servers` 分组中补充对应节点，并通过 `deploy.yaml` playbook 将监控组件补充部署完整，否则在导入后进行其他运维操作时可能会因找不到监控组件而出错。
+> + 如果使用 TiDB Ansible 部署的集群中有部分节点未部署监控，应当先使用 TiDB Ansible 在 `inventory.ini` 文件的 `monitored_servers` 分组中补充对应节点的信息，并通过 `deploy.yaml` playbook 将补充的监控组件部署完整。否则在数据导入 TiUP 后进行其他运维操作时，可能会因监控组件缺失而出错。
 
 ## 语法
 

--- a/tiup/tiup-component-cluster-import.md
+++ b/tiup/tiup-component-cluster-import.md
@@ -17,6 +17,7 @@ title: tiup cluster import
 >     + 启用了 TiDB Lightning/ Importer 的集群
 >     + 仍使用老版本 `push` 的方式收集监控指标（从 v3.0 起默认为 `pull` 模式，如果没有特意调整过则可以支持）
 >     + 在 `inventory.ini` 配置文件中单独为机器的 `node_exporter` / `blackbox_exporter` 通过 `node_exporter_port`/`blackbox_exporter_port` 设置了非默认端口（在 `group_vars` 目录中统一配置的可以兼容）
+> + 如果使用 TiDB Ansible 部署的集群中有部分节点未部署监控，应当先使用 TiDB Ansible 在 inventory 的 `monitored_servers` 分组中补充对应节点，并通过 `deploy.yaml` playbook 将监控组件补充部署完整，否则在导入后进行其他运维操作时可能会因找不到监控组件而出错。
 
 ## 语法
 


### PR DESCRIPTION
…nitored

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

Some clusters deployed by TiDB-Ansible may not having monitoring agents deployed on all nodes, and if the user imported the cluster with TiUP Cluster, future operations may fail.

This PR adds a notice to the import doc to guide the user to deploy monitoring agents to all nodes before importing to TiUP Cluster.

This PR changes the manual page of `tiup cluster import` subcommand, I'll file another PR to change the import guidance doc in the `release-4.0` branch.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
