### PR TITLE
br: add ratelimit in br commands

### DIFF
--- a/br/use-br-command-line-tool.md
+++ b/br/use-br-command-line-tool.md
@@ -399,7 +399,7 @@ BR 可以并且会默认备份 `mysql` 数据库下的表。
 {{< copyable "shell-regular" >}}
 
 ```shell
-br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage_url --ratelimit 128 
+br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage_url --ratelimit 128
 ```
 
 在如上的命令中，`-f '*.*'` 用于覆盖掉默认的规则，`-f '!mysql.*'` 指示 BR 不要恢复 `mysql` 中的表，除非另有指定。`-f 'mysql.usertable'` 则指定需要恢复 `mysql.usertable`。具体原理请参考 [table filter 的文档](/table-filter.md#表库过滤语法)。

--- a/br/use-br-command-line-tool.md
+++ b/br/use-br-command-line-tool.md
@@ -187,6 +187,7 @@ br backup full \
     --storage "s3://${Bucket}/${Folder}" \
     --s3.region "${region}" \
     --send-credentials-to-tikv=true \
+    --ratelimit 120 \
     --log-file backuptable.log
 ```
 
@@ -204,6 +205,7 @@ br backup full \
 ```shell
 br backup full\
     --pd ${PDIP}:2379 \
+    --ratelimit 120 \
     -s local:///home/tidb/backupdata/incr \
     --lastbackupts ${LAST_BACKUP_TS}
 ```
@@ -234,6 +236,7 @@ LAST_BACKUP_TS=`br validate decode --field="end-version" -s local:///home/tidb/b
 br backup raw --pd $PD_ADDR \
     -s "local://$BACKUP_DIR" \
     --start 31 \
+    --ratelimit 120 \
     --end 3130303030303030 \
     --format hex \
     --cf default
@@ -288,6 +291,7 @@ br restore full \
 br restore full \
     --pd "${PDIP}:2379" \
     --storage "local:///tmp/backup" \
+    --ratelimit 128 \
     --log-file restorefull.log
 Full Restore <---------/...............................................> 17.12%.
 ```
@@ -304,6 +308,7 @@ Full Restore <---------/...............................................> 17.12%.
 br restore db \
     --pd "${PDIP}:2379" \
     --db "test" \
+    --ratelimit 128 \
     --storage "local:///tmp/backup" \
     --log-file restorefull.log
 ```
@@ -327,6 +332,7 @@ br restore table \
     --pd "${PDIP}:2379" \
     --db "test" \
     --table "usertable" \
+    --ratelimit 128 \
     --storage "local:///tmp/backup" \
     --log-file restorefull.log
 ```
@@ -373,6 +379,7 @@ br restore full \
     --pd "${PDIP}:2379" \
     --storage "s3://${Bucket}/${Folder}" \
     --s3.region "${region}" \
+    --ratelimit 128 \
     --send-credentials-to-tikv=true \
     --log-file restorefull.log
 ```
@@ -392,7 +399,7 @@ BR 可以并且会默认备份 `mysql` 数据库下的表。
 {{< copyable "shell-regular" >}}
 
 ```shell
-br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage_url
+br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage_url --ratelimit 128 
 ```
 
 在如上的命令中，`-f '*.*'` 用于覆盖掉默认的规则，`-f '!mysql.*'` 指示 BR 不要恢复 `mysql` 中的表，除非另有指定。`-f 'mysql.usertable'` 则指定需要恢复 `mysql.usertable`。具体原理请参考 [table filter 的文档](/table-filter.md#表库过滤语法)。
@@ -402,7 +409,7 @@ br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage
 {{< copyable "shell-regular" >}}
 
 ```shell
-br restore full -f 'mysql.usertable' -s $external_storage_url
+br restore full -f 'mysql.usertable' -s $external_storage_url --ratelimit 128 
 ```
 
 > **警告：**
@@ -431,6 +438,7 @@ br restore raw --pd $PD_ADDR \
     -s "local://$BACKUP_DIR" \
     --start 31 \
     --end 3130303030303030 \
+    --ratelimit 128 \
     --format hex \
     --cf default
 ```
@@ -469,6 +477,7 @@ br restore raw --pd $PD_ADDR \
     ```shell
     br restore full \
         -s "local://$BACKUP_DIR" \
+        --ratelimit 128 \
         --pd $PD_ADDR \
         --online
     ```

--- a/br/use-br-command-line-tool.md
+++ b/br/use-br-command-line-tool.md
@@ -81,7 +81,7 @@ BR 由多层命令组成。目前，BR 包含 `backup`、`restore` 和 `version`
 br backup full \
     --pd "${PDIP}:2379" \
     --storage "local:///tmp/backup" \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backupfull.log
 ```
 
@@ -93,7 +93,7 @@ br backup full \
 br backup full \
     --pd "${PDIP}:2379" \
     --storage "local:///tmp/backup" \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backupfull.log
 Full Backup <---------/................................................> 17.12%.
 ```
@@ -111,7 +111,7 @@ br backup db \
     --pd "${PDIP}:2379" \
     --db test \
     --storage "local:///tmp/backup" \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backuptable.log
 ```
 
@@ -133,7 +133,7 @@ br backup table \
     --db test \
     --table usertable \
     --storage "local:///tmp/backup" \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backuptable.log
 ```
 
@@ -154,7 +154,7 @@ br backup full \
     --pd "${PDIP}:2379" \
     --filter 'db*.tbl*' \
     --storage "local:///tmp/backup" \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backupfull.log
 ```
 
@@ -187,7 +187,7 @@ br backup full \
     --storage "s3://${Bucket}/${Folder}" \
     --s3.region "${region}" \
     --send-credentials-to-tikv=true \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --log-file backuptable.log
 ```
 
@@ -205,7 +205,7 @@ br backup full \
 ```shell
 br backup full\
     --pd ${PDIP}:2379 \
-    --ratelimit 120 \
+    --ratelimit 128 \
     -s local:///home/tidb/backupdata/incr \
     --lastbackupts ${LAST_BACKUP_TS}
 ```
@@ -236,7 +236,7 @@ LAST_BACKUP_TS=`br validate decode --field="end-version" -s local:///home/tidb/b
 br backup raw --pd $PD_ADDR \
     -s "local://$BACKUP_DIR" \
     --start 31 \
-    --ratelimit 120 \
+    --ratelimit 128 \
     --end 3130303030303030 \
     --format hex \
     --cf default

--- a/br/use-br-command-line-tool.md
+++ b/br/use-br-command-line-tool.md
@@ -409,7 +409,7 @@ br restore full -f '*.*' -f '!mysql.*' -f 'mysql.usertable' -s $external_storage
 {{< copyable "shell-regular" >}}
 
 ```shell
-br restore full -f 'mysql.usertable' -s $external_storage_url --ratelimit 128 
+br restore full -f 'mysql.usertable' -s $external_storage_url --ratelimit 128
 ```
 
 > **警告：**


### PR DESCRIPTION
In all backup and recovery commands, add ratelimit

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
