### PR TITLE
Remove two deprecated flags

### DIFF
--- a/command-line-flags-for-tidb-configuration.md
+++ b/command-line-flags-for-tidb-configuration.md
@@ -13,12 +13,6 @@ aliases: ['/docs-cn/dev/command-line-flags-for-tidb-configuration/','/docs-cn/de
 + 默认：""
 + 必须确保用户和集群中的其他机器都能够访问到该 IP 地址
 
-## `--binlog-socket`
-
-+ TiDB 服务使用 unix socket file 方式接受内部连接，如 Pump 服务
-+ 默认：""
-+ 例如，可以使用 "/tmp/pump.sock" 来接受 Pump unix socket file 通信
-
 ## `--config`
 
 + 配置文件
@@ -99,11 +93,6 @@ aliases: ['/docs-cn/dev/command-line-flags-for-tidb-configuration/','/docs-cn/de
 + 对于 "TiKV" 存储引擎来说，path 指定的是实际的 PD 地址。假如在 192.168.100.113:2379、192.168.100.114:2379 和 192.168.100.115:2379 上面部署了 PD，那么 path 为 "192.168.100.113:2379, 192.168.100.114:2379, 192.168.100.115:2379"
 + 默认："/tmp/tidb"
 + 可以通过 `tidb-server --store=unistore --path=""` 来启动一个纯内存引擎的 TiDB
-
-## `--tmp-storage-path`
-
-+ TiDB 临时磁盘存储位置。
-+ 默认：`<操作系统临时文件夹>/tidb/tmp-storage`
 
 ## `--proxy-protocol-networks`
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

Remove two deprecated flags.
Now tidb-server has following flags:
```
Usage of ./tidb-server:
  -L string
        log level: info, debug, warn, error, fatal (default "info")
  -P string
        tidb server port (default "4000")
  -V    print version information and exit (default false)
  -advertise-address string
        tidb server advertise IP
  -affinity-cpus string
        affinity cpu (cpu-no. separated by comma, e.g. 1,2,3)
  -config string
        config file path
  -config-check
        check config file validity and exit (default false)
  -config-strict
        enforce config file validity (default false)
  -cors string
        tidb server allow cors origin
  -enable-binlog
        enable generate binlog (default false)
  -help
        show the usage
  -host string
        tidb server host (default "0.0.0.0")
  -lease string
        schema lease duration, very dangerous to change only if you know what you do (default "45s")
  -log-file string
        log file path
  -log-slow-query string
        slow query file path
  -metrics-addr string
        prometheus pushgateway address, leaves it empty will disable prometheus push.
  -metrics-interval uint
        prometheus client push interval in second, set "0" to disable prometheus push. (default 15)
  -path string
        tidb storage path (default "/tmp/tidb")
  -plugin-dir string
        the folder that hold plugin (default "/data/deploy/plugin")
  -plugin-load string
        wait load plugin name(separated by comma)
  -proxy-protocol-header-timeout uint
        proxy protocol header read timeout, unit is second. (default 5)
  -proxy-protocol-networks string
        proxy protocol networks allowed IP or *, empty mean disable proxy protocol support
  -repair-list string
        admin repair table list
  -repair-mode
        enable admin repair mode (default false)
  -report-status
        If enable status report HTTP service. (default true)
  -require-secure-transport
        require client use secure transport
  -run-ddl
        run ddl worker on this tidb-server (default true)
  -socket string
        The socket file to use for connection.
  -status string
        tidb server status port (default "10080")
  -status-host string
        tidb server status host (default "0.0.0.0")
  -store string
        registered store name, [tikv, mocktikv, unistore] (default "unistore")
```

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
