### PR TITLE
TiKV configuration: integrate writecf and lockcf to one part with defaultcf

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -857,21 +857,25 @@ Titan 相关的配置项。
 + 默认值：4
 + 最小值：1
 
-## rocksdb.defaultcf
+## rocksdb.defaultcf | rocksdb.writecf | rocksdb.lockcf
 
-rocksdb defaultcf 相关的配置项。
+`rocksdb.defaultcf`，`rocksdb.writecf`和 `rocksdb.lockcf` 相关的配置项。
 
 ### `block-size`
 
 + rocksdb block size.
-+ 默认值：64KB
++ `defaultcf`默认值：64KB
++ `writecf`默认值：64KB
++ `lockcf`默认值：16KB
 + 最小值：1KB
 + 单位：KB|MB|GB
 
 ### `block-cache-size`
 
 + rocksdb block cache size.
-+ 默认值：机器总内存 * 25%
++ `defaultcf`默认值：机器总内存 * 25%
++ `writecf`默认值：机器总内存 * 15%
++ `lockcf`默认值：机器总内存 * 2%
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -898,12 +902,16 @@ rocksdb defaultcf 相关的配置项。
 ### `optimize-filters-for-hits`
 
 + 开启优化 filter 的命中率的开关。
-+ 默认值：true
++ `defaultcf`默认值：`true`
++ `writecf`默认值：`false`
++ `lockcf`默认值：`false`
 
 ### `whole-key-filtering`
 
 + 开启将整个 key 放到 bloom filter 中的开关。
-+ 默认值：`true`
++ `defaultcf`默认值：`true`
++ `writecf`默认值：`false`
++ `lockcf`默认值：`false`
 
 ### `bloom-filter-bits-per-key`
 
@@ -938,7 +946,9 @@ bloom filter 为每个 key 预留的长度。
 ### `write-buffer-size`
 
 + memtable 大小。
-+ 默认值：128MB
++ `defaultcf`默认值：`"128MB"`
++ `writecf`默认值：`"128MB"`
++ `lockcf`默认值：`"32MB"`
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -957,7 +967,9 @@ bloom filter 为每个 key 预留的长度。
 ### `max-bytes-for-level-base`
 
 + base level (L1) 最大字节数，一般设置为 memtable 大小 4 倍。
-+ 默认值：512MB
++ `defaultcf`默认值：`"512MB"`
++ `writecf`默认值：`"512MB"`
++ `lockcf`默认值：`"128MB"`
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -971,7 +983,9 @@ bloom filter 为每个 key 预留的长度。
 ### `level0-file-num-compaction-trigger`
 
 + 触发 compaction 的 L0 文件最大个数。
-+ 默认值：4
++ `defaultcf`默认值：`4`
++ `writecf`默认值：`4`
++ `lockcf`默认值：`1`
 + 最小值：0
 
 ### `level0-slowdown-writes-trigger`
@@ -996,8 +1010,10 @@ bloom filter 为每个 key 预留的长度。
 ### `compaction-pri`
 
 + Compaction 优先类型
-+ 可选择值：3 (MinOverlappingRatio)，0 (ByCompensatedSize)，1 (OldestLargestSeqFirst)，2 (OldestSmallestSeqFirst)。
-+ 默认值：3
++ 可选择值：`0` (`ByCompensatedSize`), `1` (`OldestLargestSeqFirst`), `2` (`OldestSmallestSeqFirst`), `3` (`MinOverlappingRatio`)。
++ `defaultcf`默认值：`3`
++ `writecf`默认值：`3`
++ `lockcf`默认值：`1`
 
 ### `dynamic-level-bytes`
 
@@ -1014,7 +1030,7 @@ bloom filter 为每个 key 预留的长度。
 + 每一层的默认放大倍数。
 + 默认值：10
 
-### `rocksdb.defaultcf.compaction-style`
+### `compaction-style`
 
 + Compaction 方法，可选值为 level，universal。
 + 默认值：level
@@ -1039,7 +1055,9 @@ bloom filter 为每个 key 预留的长度。
 ### `enable-compaction-guard`
 
 + 设置 compaction guard 的启用状态。compaction guard 优化通过使用 TiKV Region 边界分割 SST 文件，帮助降低 compaction I/O，让 TiKV 能够输出较大的 SST 文件，并且在迁移 Region 时及时清理过期数据。
-+ 默认值：true
++ `defaultcf`默认值：`true`
++ `writecf`默认值：`true`
++ `lockcf`默认值：`false`
 
 ### `compaction-guard-min-output-file-size`
 
@@ -1053,9 +1071,9 @@ bloom filter 为每个 key 预留的长度。
 + 默认值：128MB
 + 单位：KB|MB|GB
 
-## rocksdb.defaultcf.titan
+## rocksdb.defaultcf.titan| rocksdb.writecf.titan | rocksdb.lockcf.titan
 
-rocksdb defaultcf titan 相关的配置项。
+`rocksdb defaultcf titan`，`rocksdb.writecf.titan`和`rocksdb.lockcf.titan` 相关的配置项。
 
 ### `min-blob-size`
 
@@ -1128,84 +1146,6 @@ rocksdb defaultcf titan 相关的配置项。
 
 + 是否开启使用 merge operator 来进行 Titan GC 写回操作，减少 Titan GC 对于前台写入的影响。
 + 默认值：false
-
-## rocksdb.writecf
-
-rocksdb writecf 相关的配置项。
-
-### `block-cache-size`
-
-+ block cache size.
-+ 默认值：机器总内存 * 15%
-+ 单位：MB|GB
-
-### `optimize-filters-for-hits`
-
-+ 开启优化 filter 的命中率的开关。
-+ 默认值：false
-
-### `whole-key-filtering`
-
-+ 开启将整个 key 放到 bloom filter 中的开关。
-+ 默认值：false
-
-### `enable-compaction-guard`
-
-+ 设置 compaction guard 的启用状态。compaction guard 优化通过使用 TiKV Region 边界分割 SST 文件，帮助降低 compaction I/O，让 TiKV 能够输出较大的 SST 文件，并且在迁移 Region 时及时清理过期数据。
-+ 默认值：true
-
-### `compression-per-level`
-
-+ 每一层默认压缩算法，默认：前两层为 No，后面 5 层为 lz4。
-+ 默认值：["no", "no", "lz4", "lz4", "lz4", "zstd", "zstd"]
-
-### `compaction-guard-min-output-file-size`
-
-+ 设置 compaction guard 启用时 SST 文件大小的最小值，防止 SST 文件过小。
-+ 默认值：8MB
-+ 单位：KB|MB|GB
-
-### `compaction-guard-max-output-file-size`
-
-+ 设置 compaction guard 启用时 SST 文件大小的最大值，防止 SST 文件过大。对于同一列族，此配置项的值会覆盖 `target-file-size-base`。
-+ 默认值：128MB
-+ 单位：KB|MB|GB
-
-## rocksdb.lockcf
-
-rocksdb lockcf 相关配置项。
-
-### `block-cache-size`
-
-+ block cache size.
-+ 默认值：机器总内存 * 2%
-+ 单位：MB|GB
-
-### `optimize-filters-for-hits`
-
-+ 开启优化 filter 的命中率的开关。
-+ 默认值：false
-
-### `whole-key-filtering`
-
-+ 开启将整个 key 放到 bloom filter 中的开关。
-+ 默认值：`true`
-
-### `compression-per-level`
-
-+ 每一层默认压缩算法。
-+ 默认值：["no", "no", "no", "no", "no", "no", "no"]
-
-### `compaction-pri`
-
-+ Compaction 优先类型
-+ 可选择值：3 (MinOverlappingRatio)，0 (ByCompensatedSize)，1 (OldestLargestSeqFirst)，2 (OldestSmallestSeqFirst)。
-+ 默认值：0
-
-### `level0-file-num-compaction-trigger`
-
-+ 触发 compaction 的 L0 文件个数。
-+ 默认值：1
 
 ## raftdb
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -859,7 +859,7 @@ Titan 相关的配置项。
 
 ## rocksdb.defaultcf | rocksdb.writecf | rocksdb.lockcf
 
-`rocksdb.defaultcf`，`rocksdb.writecf`和 `rocksdb.lockcf` 相关的配置项。
+rocksdb defaultcf，rocksdb writecf 和 rocksdb lockcf 相关的配置项。
 
 ### `block-size`
 
@@ -1073,7 +1073,7 @@ bloom filter 为每个 key 预留的长度。
 
 ## rocksdb.defaultcf.titan| rocksdb.writecf.titan | rocksdb.lockcf.titan
 
-`rocksdb defaultcf titan`，`rocksdb.writecf.titan`和`rocksdb.lockcf.titan` 相关的配置项。
+rocksdb defaultcf titan，rocksdb writecf titan 和 rocksdb lockcf titan 相关的配置项。
 
 ### `min-blob-size`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1071,9 +1071,9 @@ bloom filter 为每个 key 预留的长度。
 + 默认值：128MB
 + 单位：KB|MB|GB
 
-## rocksdb.defaultcf.titan| rocksdb.writecf.titan | rocksdb.lockcf.titan
+## rocksdb.defaultcf.titan
 
-rocksdb defaultcf titan，rocksdb writecf titan 和 rocksdb lockcf titan 相关的配置项。
+rocksdb defaultcf titan 相关的配置项。
 
 ### `min-blob-size`
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -859,23 +859,23 @@ Titan 相关的配置项。
 
 ## rocksdb.defaultcf | rocksdb.writecf | rocksdb.lockcf
 
-rocksdb defaultcf，rocksdb writecf 和 rocksdb lockcf 相关的配置项。
+rocksdb defaultcf、rocksdb writecf 和 rocksdb lockcf 相关的配置项。
 
 ### `block-size`
 
-+ rocksdb block size.
-+ `defaultcf`默认值：64KB
-+ `writecf`默认值：64KB
-+ `lockcf`默认值：16KB
++ 一个 RocksDB block 的默认大小。
++ `defaultcf` 默认值：64KB
++ `writecf` 默认值：64KB
++ `lockcf` 默认值：16KB
 + 最小值：1KB
 + 单位：KB|MB|GB
 
 ### `block-cache-size`
 
-+ rocksdb block cache size.
-+ `defaultcf`默认值：机器总内存 * 25%
-+ `writecf`默认值：机器总内存 * 15%
-+ `lockcf`默认值：机器总内存 * 2%
++ 一个 RocksDB block 的默认缓存大小。
++ `defaultcf` 默认值：机器总内存 * 25%
++ `writecf` 默认值：机器总内存 * 15%
++ `lockcf` 默认值：机器总内存 * 2%
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -902,16 +902,16 @@ rocksdb defaultcf，rocksdb writecf 和 rocksdb lockcf 相关的配置项。
 ### `optimize-filters-for-hits`
 
 + 开启优化 filter 的命中率的开关。
-+ `defaultcf`默认值：`true`
-+ `writecf`默认值：`false`
-+ `lockcf`默认值：`false`
++ `defaultcf` 默认值：`true`
++ `writecf` 默认值：`false`
++ `lockcf` 默认值：`false`
 
 ### `whole-key-filtering`
 
 + 开启将整个 key 放到 bloom filter 中的开关。
-+ `defaultcf`默认值：`true`
-+ `writecf`默认值：`false`
-+ `lockcf`默认值：`false`
++ `defaultcf` 默认值：`true`
++ `writecf` 默认值：`false`
++ `lockcf` 默认值：`false`
 
 ### `bloom-filter-bits-per-key`
 
@@ -946,9 +946,9 @@ bloom filter 为每个 key 预留的长度。
 ### `write-buffer-size`
 
 + memtable 大小。
-+ `defaultcf`默认值：`"128MB"`
-+ `writecf`默认值：`"128MB"`
-+ `lockcf`默认值：`"32MB"`
++ `defaultcf` 默认值：`"128MB"`
++ `writecf` 默认值：`"128MB"`
++ `lockcf` 默认值：`"32MB"`
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -967,9 +967,9 @@ bloom filter 为每个 key 预留的长度。
 ### `max-bytes-for-level-base`
 
 + base level (L1) 最大字节数，一般设置为 memtable 大小 4 倍。
-+ `defaultcf`默认值：`"512MB"`
-+ `writecf`默认值：`"512MB"`
-+ `lockcf`默认值：`"128MB"`
++ `defaultcf` 默认值：`"512MB"`
++ `writecf` 默认值：`"512MB"`
++ `lockcf` 默认值：`"128MB"`
 + 最小值：0
 + 单位：KB|MB|GB
 
@@ -983,9 +983,9 @@ bloom filter 为每个 key 预留的长度。
 ### `level0-file-num-compaction-trigger`
 
 + 触发 compaction 的 L0 文件最大个数。
-+ `defaultcf`默认值：`4`
-+ `writecf`默认值：`4`
-+ `lockcf`默认值：`1`
++ `defaultcf` 默认值：`4`
++ `writecf` 默认值：`4`
++ `lockcf` 默认值：`1`
 + 最小值：0
 
 ### `level0-slowdown-writes-trigger`
@@ -1010,10 +1010,10 @@ bloom filter 为每个 key 预留的长度。
 ### `compaction-pri`
 
 + Compaction 优先类型
-+ 可选择值：`0` (`ByCompensatedSize`), `1` (`OldestLargestSeqFirst`), `2` (`OldestSmallestSeqFirst`), `3` (`MinOverlappingRatio`)。
-+ `defaultcf`默认值：`3`
-+ `writecf`默认值：`3`
-+ `lockcf`默认值：`1`
++ 可选择值：`0` (`ByCompensatedSize`)，`1` (`OldestLargestSeqFirst`)，`2` (`OldestSmallestSeqFirst`)，`3` (`MinOverlappingRatio`)。
++ `defaultcf` 默认值：`3`
++ `writecf` 默认值：`3`
++ `lockcf` 默认值：`1`
 
 ### `dynamic-level-bytes`
 
@@ -1055,9 +1055,9 @@ bloom filter 为每个 key 预留的长度。
 ### `enable-compaction-guard`
 
 + 设置 compaction guard 的启用状态。compaction guard 优化通过使用 TiKV Region 边界分割 SST 文件，帮助降低 compaction I/O，让 TiKV 能够输出较大的 SST 文件，并且在迁移 Region 时及时清理过期数据。
-+ `defaultcf`默认值：`true`
-+ `writecf`默认值：`true`
-+ `lockcf`默认值：`false`
++ `defaultcf` 默认值：`true`
++ `writecf` 默认值：`true`
++ `lockcf` 默认值：`false`
 
 ### `compaction-guard-min-output-file-size`
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
integrated rockdb.writecf and rockdb.lockcf in one part with defaultcf
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: [#5746](https://github.com/pingcap/docs/pull/5746), [#5936](https://github.com/pingcap/docs/pull/5936).
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
