### PR TITLE
Revert "TiKV update reserve-space config-param"

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -19,6 +19,7 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 
     + 如果此配置项值为 false ，当 TiKV panic 时，TiKV 调用 `exit()` 退出进程。
     + 如果此配置项值为 true ，当 TiKV panic 时，TiKV 调用 `abort()` 退出进程。此时 TiKV 允许系统在退出时生成 core dump 文件。要生成 core dump 文件，你还需要进行 core dump 相关的系统配置（比如打开 `ulimit -c` 和配置 core dump 路径，不同操作系统配置方式不同）。建议将 core dump 生成路径设置在 TiKV 数据的不同磁盘分区，避免 core dump 文件占用磁盘空间过大，造成 TiKV 磁盘空间不足。
+
 + 默认值：false
 
 ## server

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -19,7 +19,7 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 
     + 如果此配置项值为 false ，当 TiKV panic 时，TiKV 调用 `exit()` 退出进程。
     + 如果此配置项值为 true ，当 TiKV panic 时，TiKV 调用 `abort()` 退出进程。此时 TiKV 允许系统在退出时生成 core dump 文件。要生成 core dump 文件，你还需要进行 core dump 相关的系统配置（比如打开 `ulimit -c` 和配置 core dump 路径，不同操作系统配置方式不同）。建议将 core dump 生成路径设置在 TiKV 数据的不同磁盘分区，避免 core dump 文件占用磁盘空间过大，造成 TiKV 磁盘空间不足。
-
+    
 + 默认值：false
 
 ## server
@@ -281,11 +281,7 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 
 ### `reserve-space`
 
-+ TiKV 启动时会预留一块磁盘空间用于防护磁盘被写满。预留空间大小为 TiKV 存储容量的百分之五与本配置参数之间的最大值。预留空间中 80% 的空间用作软防御，20% 的空间用作磁盘占位符。占位符名称为 `space_placeholder_file`，位于 `storage.data-dir` 目录下，用于防止极端场景下软防御空间也被写满而导致 TiKV Crash。
-
-    - 当磁盘可用空间不足预留空间时，业务正常写操作失败会返回 Disk_Full 错误码。此时需要运维干预进行扩容，或者执行 Drop Table 释放空间。
-    - 当 TiKV 磁盘空间耗尽无法正常启动需要紧急干预时，可以删除 `space_placeholder_file` 文件，并且将 `reserve-space` 设置为 `0MB`（代表关闭磁盘防护功能）。待 TiKV 实例的存储空间充足后，建议重新设置该参数，以启用磁盘防护功能。
-    
++ TiKV 启动时预占额外空间的临时文件大小。临时文件名为 `space_placeholder_file`，位于 `storage.data-dir` 目录下。TiKV 磁盘空间耗尽无法正常启动需要紧急干预时，可以删除该文件，并且将 `reserve-space` 设置为 `0MB`。
 + 默认值：5GB
 + 单位：MB|GB
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -19,7 +19,6 @@ TiKV 配置文件比命令行参数支持更多的选项。你可以在 [etc/con
 
     + 如果此配置项值为 false ，当 TiKV panic 时，TiKV 调用 `exit()` 退出进程。
     + 如果此配置项值为 true ，当 TiKV panic 时，TiKV 调用 `abort()` 退出进程。此时 TiKV 允许系统在退出时生成 core dump 文件。要生成 core dump 文件，你还需要进行 core dump 相关的系统配置（比如打开 `ulimit -c` 和配置 core dump 路径，不同操作系统配置方式不同）。建议将 core dump 生成路径设置在 TiKV 数据的不同磁盘分区，避免 core dump 文件占用磁盘空间过大，造成 TiKV 磁盘空间不足。
-    
 + 默认值：false
 
 ## server


### PR DESCRIPTION
### What is changed, added or deleted?
Because the reserve-space config-param feature will not enter the v5.2 feature list, this PR reverts https://github.com/pingcap/docs-cn/pull/6845

### Which TiDB version(s) do your changes apply to?
- [x] master (the latest development version)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: 

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch