### PR TITLE
Tune TiKV: change the default value of `grpc-concurrency`

### DIFF
--- a/tune-tikv-thread-performance.md
+++ b/tune-tikv-thread-performance.md
@@ -30,7 +30,7 @@ TiKV 的读取请求分为两类：
 
 ## TiKV 线程池调优
 
-* gRPC 线程池的大小默认配置 (`server.grpc-concurrency`) 是 4。由于 gRPC 线程池几乎不会有多少计算开销，它主要负责网络 IO、反序列化请求，因此该配置通常不需要调整。
+* gRPC 线程池的大小默认配置 (`server.grpc-concurrency`) 是 5。由于 gRPC 线程池几乎不会有多少计算开销，它主要负责网络 IO、反序列化请求，因此该配置通常不需要调整。
 
     - 如果部署的机器 CPU 核数特别少（小于等于 8），可以考虑将该配置 (`server.grpc-concurrency`) 设置为 2。
     - 如果机器配置很高，并且 TiKV 承担了非常大量的读写请求，观察到 Grafana 上的监控 Thread CPU 的 gRPC poll CPU 的数值超过了 server.grpc-concurrency 大小的 80%，那么可以考虑适当调大 `server.grpc-concurrency` 以控制该线程池使用率在 80% 以下（即 Grafana 上的指标低于 `80% * server.grpc-concurrency` 的值）。


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Changed the default value of `server.grpc-concurrency` from 4 to 5 in "tune-tikv-thread-performance.md" according to "tikv-configuration-file.md".
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: 
- Other reference link(s): [#7088](https://github.com/pingcap/docs-cn/issues/7088)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
