### PR TITLE
Update version info about default enabled Placement Rules

### DIFF
--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -71,7 +71,7 @@ Placement Rules 示意图如下所示：
 
 本节的操作步骤以使用 [pd-ctl](/pd-control.md) 工具为例，涉及到的命令也支持通过 HTTP API 进行调用。
 
-### 开启 Placement Rules 特性
+### 开启 Placement Rules 功能
 
 Placement Rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。如需手动开启这个特性，可以[集群初始化以前设置 PD 配置文件](/###关闭-placement-rules-特性)：
 
@@ -82,7 +82,7 @@ Placement Rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。�
 enable-placement-rules = true
 ```
 
-这样，PD 在初始化成功后会开启这个特性，并根据 `max-replicas` 及 `location-labels` 配置生成对应的规则：
+这样，PD 在初始化成功后会开启这个功能，并根据 `max-replicas` 及 `location-labels` 配置生成对应的规则：
 
 {{< copyable "" >}}
 
@@ -113,9 +113,9 @@ PD 同样将根据系统的 `max-replicas` 及 `location-labels` 生成默认的
 >
 > 开启 Placement Rules 后，原先的 `max-replicas` 及 `location-labels` 配置项将不再生效。如果需要调整副本策略，应当使用 Placement Rules 相关接口。
 
-### 关闭 Placement Rules 特性
+### 关闭 Placement Rules 功能
 
-使用 pd-ctl 可以关闭 Placement Rules 特性，切换为之前的调度策略。
+使用 pd-ctl 可以关闭 Placement Rules 功能，切换为之前的调度策略。
 
 {{< copyable "shell-regular" >}}
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -71,7 +71,7 @@ Placement Rules 示意图如下所示：
 
 ### 开启 Placement Rules 特性
 
-Placement rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。如需手动开启这个特性，可以[集群初始化以前设置 PD 配置文件](/###关闭-placement-rules-特性)：
+Placement Rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。如需手动开启这个特性，可以[集群初始化以前设置 PD 配置文件](/###关闭-placement-rules-特性)：
 
 {{< copyable "" >}}
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/dev/configure-placement-rules/','/docs-cn/dev/how-to/configu
 
 Placement Rules 是 PD 在 4.0 版本引入的试验特性，它是一套副本规则系统，用于指导 PD 针对不同类型的数据生成对应的调度。通过组合不同的调度规则，用户可以精细地控制任何一段连续数据的副本数量、存放位置、主机类型、是否参与 Raft 投票、是否可以担任 Raft leader 等属性。
 
-Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](/###关闭-placement-rules-特性)。
+Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](#关闭-placement-rules-特性)。
 
 ## 规则系统介绍
 
@@ -73,7 +73,7 @@ Placement Rules 示意图如下所示：
 
 ### 开启 Placement Rules 特性
 
-Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](/###关闭-placement-rules-特性)。如需在关闭后重新开启该特性，可以集群初始化以前设置 PD 配置文件：
+Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](#关闭-placement-rules-特性)。如需在关闭后重新开启该特性，可以集群初始化以前设置 PD 配置文件：
 
 {{< copyable "" >}}
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -12,6 +12,8 @@ aliases: ['/docs-cn/dev/configure-placement-rules/','/docs-cn/dev/how-to/configu
 
 Placement Rules 是 PD 在 4.0 版本引入的试验特性，它是一套副本规则系统，用于指导 PD 针对不同类型的数据生成对应的调度。通过组合不同的调度规则，用户可以精细地控制任何一段连续数据的副本数量、存放位置、主机类型、是否参与 Raft 投票、是否可以担任 Raft leader 等属性。
 
+Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules] (/###关闭-placement-rules-特性)。
+
 ## 规则系统介绍
 
 整个规则系统的配置由多条规则即 Rule 组成。每条 Rule 可以指定不同的副本数量、Raft 角色、放置位置等属性，以及这条规则生效的 key range。PD 在进行调度时，会先根据 Region 的 key range 在规则系统中查到该 Region 对应的规则，然后再生成对应的调度，来使得 Region 副本的分布情况符合 Rule。

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -12,7 +12,7 @@ aliases: ['/docs-cn/dev/configure-placement-rules/','/docs-cn/dev/how-to/configu
 
 Placement Rules 是 PD 在 4.0 版本引入的试验特性，它是一套副本规则系统，用于指导 PD 针对不同类型的数据生成对应的调度。通过组合不同的调度规则，用户可以精细地控制任何一段连续数据的副本数量、存放位置、主机类型、是否参与 Raft 投票、是否可以担任 Raft leader 等属性。
 
-Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules] (/###关闭-placement-rules-特性)。
+Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](/###关闭-placement-rules-特性)。
 
 ## 规则系统介绍
 
@@ -73,7 +73,7 @@ Placement Rules 示意图如下所示：
 
 ### 开启 Placement Rules 功能
 
-Placement Rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。如需手动开启这个特性，可以[集群初始化以前设置 PD 配置文件](/###关闭-placement-rules-特性)：
+Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](/###关闭-placement-rules-特性)。如需在关闭后重新开启该特性，可以集群初始化以前设置 PD 配置文件：
 
 {{< copyable "" >}}
 
@@ -82,7 +82,7 @@ Placement Rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。�
 enable-placement-rules = true
 ```
 
-这样，PD 在初始化成功后会开启这个功能，并根据 `max-replicas` 及 `location-labels` 配置生成对应的规则：
+这样，PD 在初始化成功后会开启这个特性，并根据 `max-replicas` 及 `location-labels` 配置生成对应的规则：
 
 {{< copyable "" >}}
 
@@ -113,9 +113,9 @@ PD 同样将根据系统的 `max-replicas` 及 `location-labels` 生成默认的
 >
 > 开启 Placement Rules 后，原先的 `max-replicas` 及 `location-labels` 配置项将不再生效。如果需要调整副本策略，应当使用 Placement Rules 相关接口。
 
-### 关闭 Placement Rules 功能
+### 关闭 Placement Rules 特性
 
-使用 pd-ctl 可以关闭 Placement Rules 功能，切换为之前的调度策略。
+使用 pd-ctl 可以关闭 Placement Rules 特性，切换为之前的调度策略。
 
 {{< copyable "shell-regular" >}}
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -71,7 +71,7 @@ Placement Rules 示意图如下所示：
 
 本节的操作步骤以使用 [pd-ctl](/pd-control.md) 工具为例，涉及到的命令也支持通过 HTTP API 进行调用。
 
-### 开启 Placement Rules 功能
+### 开启 Placement Rules 特性
 
 Placement Rules 特性在 TiDB v5.0 及以上的版本中默认开启。如需关闭 Placement Rules 特性，请参考[关闭 Placement Rules](/###关闭-placement-rules-特性)。如需在关闭后重新开启该特性，可以集群初始化以前设置 PD 配置文件：
 

--- a/configure-placement-rules.md
+++ b/configure-placement-rules.md
@@ -71,7 +71,7 @@ Placement Rules 示意图如下所示：
 
 ### 开启 Placement Rules 特性
 
-默认情况下，Placement Rules 特性是关闭的。要开启这个特性，可以集群初始化以前设置 PD 配置文件：
+Placement rules 特性在 TiDB v5.0 及以上的版本中是默认开启的。如需手动开启这个特性，可以[集群初始化以前设置 PD 配置文件](/###关闭-placement-rules-特性)：
 
 {{< copyable "" >}}
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
I have updated version info about default enabled Placement Rules in "configure-placement-rules.md" because this feature is enabled by default since TiDB v 5.0.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs-cn/issues/7239

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
