### PR TITLE
SQL prepare execution plan cache: add the experimental feature warning 

### DIFF
--- a/experimental-features.md
+++ b/experimental-features.md
@@ -29,6 +29,7 @@ summary: 了解 TiDB 各版本的实验特性。
 + [自定义变量](/user-defined-variables.md#用户自定义变量)。
 + [JSON 数据类型](/data-type-json.md)及 [JSON 函数](/functions-and-operators/json-functions.md)。
 + [View](/information-schema/information-schema-views.md)。
++ [执行计划缓存](/sql-prepare-plan-cache.md)。
 
 ## 配置管理
 

--- a/sql-prepare-plan-cache.md
+++ b/sql-prepare-plan-cache.md
@@ -4,6 +4,10 @@ title: 执行计划缓存
 
 # 执行计划缓存
 
+> **警告：**
+>
+> 该功能目前为实验特性，不建议在生产环境中使用。
+
 TiDB 支持对 `Prepare` / `Execute` 请求的执行计划缓存。其中包括以下两种形式的预处理语句：
 
 - 使用 `COM_STMT_PREPARE` 和 `COM_STMT_EXECUTE` 的协议功能；


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
n.

### What is changed, added or deleted? (Required)

The SQL prepare execution plan cache feature is experimental for v4.0, v5.0, v5.1, and v5.2. This PR adds the experimental feature warning for this feature.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)
- [x] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
