### PR TITLE
chore: remove useless aliases for DM Dev docs 

### DIFF
--- a/dm/deploy-a-dm-cluster-using-tiup.md
+++ b/dm/deploy-a-dm-cluster-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: 使用 TiUP 部署 DM 集群
 summary: 学习如何使用 TiUP DM 组件来部署 TiDB Data Migration 工具。
-aliases: ['/docs-cn/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible/','/zh/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible']
+aliases: ['/docs-cn/tidb-data-migration/dev/deploy-a-dm-cluster-using-ansible/']
 ---
 
 # 使用 TiUP 部署 DM 集群

--- a/dm/dm-alert-rules.md
+++ b/dm/dm-alert-rules.md
@@ -1,7 +1,7 @@
 ---
 title: DM 告警信息
 summary: 介绍 DM 的告警信息。
-aliases: ['/docs-cn/tidb-data-migration/dev/alert-rules/','/zh/tidb-data-migration/dev/alert-rules/']
+aliases: ['/docs-cn/tidb-data-migration/dev/alert-rules/']
 ---
 
 # DM 告警信息

--- a/dm/dm-benchmark-v5.3.0.md
+++ b/dm/dm-benchmark-v5.3.0.md
@@ -1,7 +1,6 @@
 ---
 title: DM 5.3.0 性能测试报告
 summary: 了解 DM 5.3.0 版本的性能。
-aliases: ['/zh/tidb-data-migration/dev/benchmark-v5.3.0/']
 ---
 
 # DM 5.3.0 性能测试报告

--- a/dm/dm-command-line-flags.md
+++ b/dm/dm-command-line-flags.md
@@ -1,7 +1,7 @@
 ---
 title: DM 命令行参数
 summary: 介绍 DM 各组件的主要命令行参数。
-aliases: ['/docs-cn/tidb-data-migration/dev/command-line-flags/','/zh/tidb-data-migration/dev/command-line-flags/']
+aliases: ['/docs-cn/tidb-data-migration/dev/command-line-flags/']
 ---
 
 # DM 命令行参数

--- a/dm/dm-config-overview.md
+++ b/dm/dm-config-overview.md
@@ -1,6 +1,6 @@
 ---
 title: DM 配置简介
-aliases: ['/docs-cn/tidb-data-migration/dev/config-overview/','/zh/tidb-data-migration/dev/config-overview/']
+aliases: ['/docs-cn/tidb-data-migration/dev/config-overview/']
 ---
 
 # DM 配置简介

--- a/dm/dm-create-task.md
+++ b/dm/dm-create-task.md
@@ -1,7 +1,7 @@
 ---
 title: 创建数据迁移任务
 summary: 了解 TiDB Data Migration 如何创建数据迁移任务。
-aliases: ['/docs-cn/tidb-data-migration/dev/create-task/','/zh/tidb-data-migration/dev/create-task/']
+aliases: ['/docs-cn/tidb-data-migration/dev/create-task/']
 ---
 
 # 创建数据迁移任务

--- a/dm/dm-daily-check.md
+++ b/dm/dm-daily-check.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration 日常巡检
 summary: 了解 DM 工具的日常巡检。
-aliases: ['/docs-cn/tidb-data-migration/dev/daily-check/','/zh/tidb-data-migration/dev/daily-check/']
+aliases: ['/docs-cn/tidb-data-migration/dev/daily-check/']
 ---
 
 # TiDB Data Migration 日常巡检

--- a/dm/dm-enable-tls.md
+++ b/dm/dm-enable-tls.md
@@ -1,7 +1,6 @@
 ---
 title: 为 DM 的连接开启加密传输
 summary: 了解如何为 DM 的连接开启加密传输。
-aliases: ['/zh/tidb-data-migration/dev/enable-tls/']
 ---
 
 # 为 DM 的连接开启加密传输

--- a/dm/dm-error-handling.md
+++ b/dm/dm-error-handling.md
@@ -1,7 +1,7 @@
 ---
 title: 故障及处理方法
 summary: 了解 DM 的错误系统及常见故障的处理方法。
-aliases: ['/docs-cn/tidb-data-migration/dev/error-handling/','/docs-cn/tidb-data-migration/dev/troubleshoot-dm/','/docs-cn/tidb-data-migration/dev/error-system/','/zh/tidb-data-migration/dev/error-handling/']
+aliases: ['/docs-cn/tidb-data-migration/dev/error-handling/','/docs-cn/tidb-data-migration/dev/troubleshoot-dm/','/docs-cn/tidb-data-migration/dev/error-system/']
 ---
 
 # 故障及处理方法

--- a/dm/dm-export-import-config.md
+++ b/dm/dm-export-import-config.md
@@ -1,7 +1,6 @@
 ---
 title: 导出和导入集群的数据源和任务配置
 summary: 了解 TiDB Data Migration 导出和导入集群的数据源和任务配置。
-aliases: ['/zh/tidb-data-migration/dev/export-import-config/']
 ---
 
 # 导出和导入集群的数据源和任务配置

--- a/dm/dm-faq.md
+++ b/dm/dm-faq.md
@@ -1,6 +1,6 @@
 ---
 title: Data Migration 常见问题
-aliases: ['/docs-cn/tidb-data-migration/dev/faq/','/zh/tidb-data-migration/dev/faq/']
+aliases: ['/docs-cn/tidb-data-migration/dev/faq/']
 ---
 
 # Data Migration 常见问题

--- a/dm/dm-generate-self-signed-certificates.md
+++ b/dm/dm-generate-self-signed-certificates.md
@@ -1,7 +1,6 @@
 ---
 title: 生成自签名证书
 summary: 了解如何生成自签名证书。
-aliases: ['/zh/tidb-data-migration/dev/generate-self-signed-certificates/']
 ---
 
 # 生成自签名证书

--- a/dm/dm-glossary.md
+++ b/dm/dm-glossary.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration 术语表
 summary: 学习 TiDB Data Migration 相关术语
-aliases: ['/docs-cn/tidb-data-migration/dev/glossary/','/zh/tidb-data-migration/dev/glossary']
+aliases: ['/docs-cn/tidb-data-migration/dev/glossary/']
 ---
 
 # TiDB Data Migration 术语表

--- a/dm/dm-handle-alerts.md
+++ b/dm/dm-handle-alerts.md
@@ -1,7 +1,7 @@
 ---
 title: 处理告警
 summary: 了解 DM 中各主要告警信息的处理方法。
-aliases: ['/docs-cn/tidb-data-migration/dev/handle-alerts/','/zh/tidb-data-migration/dev/handle-alerts/']
+aliases: ['/docs-cn/tidb-data-migration/dev/handle-alerts/']
 ---
 
 # 处理告警

--- a/dm/dm-handle-performance-issues.md
+++ b/dm/dm-handle-performance-issues.md
@@ -1,7 +1,7 @@
 ---
 title: 性能问题及处理方法
 summary: 了解 DM 可能存在的常见性能问题及其处理方法。
-aliases: ['/docs-cn/tidb-data-migration/dev/handle-performance-issues/','/zh/tidb-data-migration/dev/handle-performance-issues/']
+aliases: ['/docs-cn/tidb-data-migration/dev/handle-performance-issues/']
 ---
 
 # 性能问题及处理方法

--- a/dm/dm-hardware-and-software-requirements.md
+++ b/dm/dm-hardware-and-software-requirements.md
@@ -1,7 +1,7 @@
 ---
 title: DM 集群软硬件环境需求
 summary: 了解部署 DM 集群的软件和硬件要求。
-aliases: ['/docs-cn/tidb-data-migration/dev/hardware-and-software-requirements/','/zh/tidb-data-migration/dev/hardware-and-software-requirements/']
+aliases: ['/docs-cn/tidb-data-migration/dev/hardware-and-software-requirements/']
 ---
 
 # DM 集群软硬件环境需求

--- a/dm/dm-key-features.md
+++ b/dm/dm-key-features.md
@@ -1,7 +1,7 @@
 ---
 title: 主要特性
 summary: 了解 DM 的各主要功能特性或相关的配置选项。
-aliases: ['/docs-cn/tidb-data-migration/dev/key-features/','/docs-cn/tidb-data-migration/dev/feature-overview/','/zh/tidb-data-migration/dev/key-features/']
+aliases: ['/docs-cn/tidb-data-migration/dev/key-features/','/docs-cn/tidb-data-migration/dev/feature-overview/']
 ---
 
 # 主要特性

--- a/dm/dm-manage-schema.md
+++ b/dm/dm-manage-schema.md
@@ -1,7 +1,6 @@
 ---
 title: 管理迁移表的表结构
 summary: 了解如何管理待迁移表在 DM 内部的表结构。
-aliases: ['/zh/tidb-data-migration/dev/manage-schema/']
 ---
 
 # 管理迁移表的表结构

--- a/dm/dm-manage-source.md
+++ b/dm/dm-manage-source.md
@@ -1,7 +1,7 @@
 ---
 title: 管理上游数据源
 summary: 了解如何管理上游 MySQL 实例。
-aliases: ['/docs-cn/tidb-data-migration/dev/manage-source/','/zh/tidb-data-migration/dev/manage-source/']
+aliases: ['/docs-cn/tidb-data-migration/dev/manage-source/']
 ---
 
 # 管理上游数据源配置

--- a/dm/dm-open-api.md
+++ b/dm/dm-open-api.md
@@ -1,7 +1,6 @@
 ---
 title: 使用 OpenAPI 运维集群
 summary: 了解如何使用 OpenAPI 接口来管理集群状态和数据同步。
-aliases: ['/zh/tidb-data-migration/dev/open-api/']
 ---
 
 # 使用 OpenAPI 运维集群

--- a/dm/dm-overview.md
+++ b/dm/dm-overview.md
@@ -1,7 +1,7 @@
 ---
 title: Data Migration 简介
 summary: 了解 TiDB Data Migration
-aliases: ['/docs-cn/tidb-data-migration/dev/overview/','/docs-cn/tools/dm/overview/','/zh/tidb-data-migration/dev/overview/']
+aliases: ['/docs-cn/tidb-data-migration/dev/overview/','/docs-cn/tools/dm/overview/']
 ---
 
 # Data Migration 简介

--- a/dm/dm-pause-task.md
+++ b/dm/dm-pause-task.md
@@ -1,7 +1,7 @@
 ---
 title: 暂停数据迁移任务
 summary: 了解 TiDB Data Migration 如何暂停数据迁移任务。
-aliases: ['/docs-cn/tidb-data-migration/dev/pause-task/','/zh/tidb-data-migration/dev/pause-task/']
+aliases: ['/docs-cn/tidb-data-migration/dev/pause-task/']
 ---
 
 # 暂停数据迁移任务

--- a/dm/dm-performance-test.md
+++ b/dm/dm-performance-test.md
@@ -1,7 +1,7 @@
 ---
 title: DM 集群性能测试
 summary: 了解如何测试 DM 集群的性能。
-aliases: ['/docs-cn/tidb-data-migration/dev/performance-test/','/zh/tidb-data-migration/dev/performance-test/']
+aliases: ['/docs-cn/tidb-data-migration/dev/performance-test/']
 ---
 
 # DM 集群性能测试

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -1,7 +1,7 @@
 ---
 title: 上游 MySQL 实例配置前置检查
 summary: 了解上游 MySQL 实例配置前置检查。
-aliases: ['/docs-cn/tidb-data-migration/dev/precheck/','/zh/tidb-data-migration/dev/precheck/']
+aliases: ['/docs-cn/tidb-data-migration/dev/precheck/']
 ---
 
 # 上游 MySQL 实例配置前置检查

--- a/dm/dm-query-status.md
+++ b/dm/dm-query-status.md
@@ -1,7 +1,7 @@
 ---
 title: TiDB Data Migration 查询状态
 summary: 深入了解 TiDB Data Migration 如何查询数据迁移任务状态
-aliases: ['/docs-cn/tidb-data-migration/dev/query-status/','/docs-cn/tidb-data-migration/dev/query-error/','/tidb-data-migration/dev/query-error/','/zh/tidb-data-migration/dev/query-status/']
+aliases: ['/docs-cn/tidb-data-migration/dev/query-status/','/docs-cn/tidb-data-migration/dev/query-error/','/tidb-data-migration/dev/query-error/']
 ---
 
 # TiDB Data Migration 查询状态

--- a/dm/dm-resume-task.md
+++ b/dm/dm-resume-task.md
@@ -1,7 +1,7 @@
 ---
 title: 恢复数据迁移任务
 summary: 了解 TiDB Data Migration 如何恢复数据迁移任务。
-aliases: ['/docs-cn/tidb-data-migration/dev/resume-task/','/zh/tidb-data-migration/dev/resume-task/']
+aliases: ['/docs-cn/tidb-data-migration/dev/resume-task/']
 ---
 
 # 恢复数据迁移任务

--- a/dm/dm-source-configuration-file.md
+++ b/dm/dm-source-configuration-file.md
@@ -1,6 +1,6 @@
 ---
 title: 上游数据库配置文件介绍
-aliases: ['/docs-cn/tidb-data-migration/dev/source-configuration-file/','/zh/tidb-data-migration/dev/source-configuration-file/']
+aliases: ['/docs-cn/tidb-data-migration/dev/source-configuration-file/']
 ---
 
 # 上游数据库配置文件介绍

--- a/dm/dm-stop-task.md
+++ b/dm/dm-stop-task.md
@@ -1,7 +1,7 @@
 ---
 title: 停止数据迁移任务
 summary: 了解 TiDB Data Migration 如何停止数据迁移任务。
-aliases: ['/docs-cn/tidb-data-migration/dev/stop-task/','/zh/tidb-data-migration/dev/stop-task/']
+aliases: ['/docs-cn/tidb-data-migration/dev/stop-task/']
 ---
 
 # 停止数据迁移任务

--- a/dm/dm-task-configuration-guide.md
+++ b/dm/dm-task-configuration-guide.md
@@ -1,6 +1,5 @@
 ---
 title: DM 数据迁移任务配置向导
-aliases: ['/zh/tidb-data-migration/dev/task-configuration-guide/']
 ---
 
 # 数据迁移任务配置向导

--- a/dm/dm-tune-configuration.md
+++ b/dm/dm-tune-configuration.md
@@ -1,7 +1,7 @@
 ---
 title: DM 配置优化
 summary: 介绍如何通过优化配置来提高数据迁移性能。
-aliases: ['/docs-cn/tidb-data-migration/dev/tune-configuration/','/zh/tidb-data-migration/dev/tune-configuration/']
+aliases: ['/docs-cn/tidb-data-migration/dev/tune-configuration/']
 ---
 
 # DM 配置优化

--- a/dm/handle-failed-ddl-statements.md
+++ b/dm/handle-failed-ddl-statements.md
@@ -1,7 +1,7 @@
 ---
 title: 处理出错的 DDL 语句
 summary: 了解在使用 TiDB Data Migration 迁移数据时，如何处理出错的 DDL 语句。
-aliases: ['/docs-cn/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/','/zh/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements','/zh/tidb-data-migration/dev/handle-failed-sql-statements']
+aliases: ['/docs-cn/tidb-data-migration/dev/skip-or-replace-abnormal-sql-statements/']
 ---
 
 # 处理出错的 DDL 语句

--- a/dm/maintain-dm-using-tiup.md
+++ b/dm/maintain-dm-using-tiup.md
@@ -1,7 +1,7 @@
 ---
 title: 使用 TiUP 运维 DM 集群
 summary: 学习如何使用 TiUP 运维 DM 集群。
-aliases: ['/docs-cn/tidb-data-migration/dev/cluster-operations/','/zh/tidb-data-migration/dev/cluster-operations']
+aliases: ['/docs-cn/tidb-data-migration/dev/cluster-operations/']
 ---
 
 # 使用 TiUP 运维 DM 集群

--- a/dm/migrate-data-using-dm.md
+++ b/dm/migrate-data-using-dm.md
@@ -1,6 +1,6 @@
 ---
 title: 使用 DM 迁移数据
-aliases: ['/docs-cn/tidb-data-migration/dev/replicate-data-using-dm/','/zh/tidb-data-migration/dev/replicate-data-using-dm']
+aliases: ['/docs-cn/tidb-data-migration/dev/replicate-data-using-dm/']
 ---
 
 # 使用 DM 迁移数据

--- a/dm/quick-start-create-task.md
+++ b/dm/quick-start-create-task.md
@@ -1,7 +1,7 @@
 ---
 title: 创建数据迁移任务
 summary: 了解在部署 DM 集群后，如何快速创建数据迁移任务。
-aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-create-task/','/zh/tidb-data-migration/dev/create-task-and-verify']
+aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-create-task/']
 ---
 
 # 创建数据迁移任务

--- a/dm/task-configuration-file-full.md
+++ b/dm/task-configuration-file-full.md
@@ -1,6 +1,6 @@
 ---
 title: DM 任务完整配置文件介绍
-aliases: ['/docs-cn/tidb-data-migration/dev/task-configuration-file-full/','/zh/tidb-data-migration/dev/dm-portal','/docs-cn/tidb-data-migration/dev/dm-portal/']
+aliases: ['/docs-cn/tidb-data-migration/dev/task-configuration-file-full/','/docs-cn/tidb-data-migration/dev/dm-portal/']
 ---
 
 # DM 任务完整配置文件介绍

--- a/dm/usage-scenario-simple-migration.md
+++ b/dm/usage-scenario-simple-migration.md
@@ -1,6 +1,6 @@
 ---
 title: 多数据源合并迁移到 TiDB
-aliases: ['/docs-cn/tidb-data-migration/dev/usage-scenario-simple-replication/','/zh/tidb-data-migration/dev/usage-scenario-simple-replication']
+aliases: ['/docs-cn/tidb-data-migration/dev/usage-scenario-simple-replication/']
 ---
 
 # 多数据源合并迁移到 TiDB


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR removes useless aliases that start with '/zh/tidb-data-migration/dev/' for DM Dev docs. Those aliases are useless because all the existing DM Dev docs will be directed to https://docs.pingcap.com/zh/tidb/dev/dm-overview so users could be aware of the doc location changes easily. 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)
- [ ] v3.1 (TiDB 3.1 versions)
- [ ] v3.0 (TiDB 3.0 versions)
- [ ] v2.1 (TiDB 2.1 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [x] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
