### PR TITLE
Remove `/bin` from toolkit commands

### DIFF
--- a/get-started-with-tidb-lightning.md
+++ b/get-started-with-tidb-lightning.md
@@ -25,7 +25,7 @@ TiDB Lightning 是一个将全量数据高速导入到 TiDB 集群的工具，�
 {{< copyable "shell-regular" >}}
 
 ```sh
-./bin/dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
+./dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
 ```
 
 其中：

--- a/sync-diff-inspector/sync-diff-inspector-overview.md
+++ b/sync-diff-inspector/sync-diff-inspector-overview.md
@@ -170,7 +170,7 @@ collation = ""
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/sync_diff_inspector --config=./config.toml
+./sync_diff_inspector --config=./config.toml
 ```
 
 该命令最终会在 `config.toml` 中的 `output-dir` 输出目录输出本次比对的检查报告 `summary.txt` 和日志 `sync_diff.log`。在输出目录下还会生成由 `config.toml` 文件内容哈希值命名的文件夹，该文件夹下包括断点续传 checkpoint 结点信息以及数据存在不一致时生成的 SQL 修复数据。

--- a/tidb-binlog/deploy-tidb-binlog.md
+++ b/tidb-binlog/deploy-tidb-binlog.md
@@ -139,7 +139,7 @@ Drainer="192.168.0.13"
         {{< copyable "shell-regular" >}}
 
         ```bash
-        ./bin/pump -config pump.toml
+        ./pump -config pump.toml
         ```
 
         如果命令行参数与配置文件中的参数重合，则使用命令行设置的参数的值。
@@ -348,7 +348,7 @@ Drainer="192.168.0.13"
         {{< copyable "shell-regular" >}}
 
         ```bash
-        ./bin/drainer -config drainer.toml -initial-commit-ts {initial-commit-ts}
+        ./drainer -config drainer.toml -initial-commit-ts {initial-commit-ts}
         ```
 
         如果命令行参数与配置文件中的参数重合，则使用命令行设置的参数的值。

--- a/tidb-binlog/get-started-with-tidb-binlog.md
+++ b/tidb-binlog/get-started-with-tidb-binlog.md
@@ -156,7 +156,7 @@ cd tidb-latest-linux-amd64
     {{< copyable "shell-regular" >}}
 
     ```bash
-    ./bin/pump --config=pump.toml &>pump.out &
+    ./pump --config=pump.toml &>pump.out &
     ```
 
     ```
@@ -185,7 +185,7 @@ cd tidb-latest-linux-amd64
     ```
     [1]   Running                 ./bin/pd-server --config=pd.toml &>pd.out &
     [2]   Running                 ./bin/tikv-server --config=tikv.toml &>tikv.out &
-    [3]-  Running                 ./bin/pump --config=pump.toml &>pump.out &
+    [3]-  Running                 ./pump --config=pump.toml &>pump.out &
     [4]+  Running                 ./bin/tidb-server --config=tidb.toml &>tidb.out &
     ```
 
@@ -223,7 +223,7 @@ Check Table Before Drop: false
 
     ```bash
     sudo systemctl start mariadb &&
-    ./bin/drainer --config=drainer.toml &>drainer.out &
+    ./drainer --config=drainer.toml &>drainer.out &
     ```
 
     如果你的操作系统更易于安装 MySQL，只需保证监听 3306 端口。另外，可使用密码为空的 "root" 用户连接到 MySQL，或调整 `drainer.toml` 连接到 MySQL。
@@ -424,7 +424,7 @@ Check Table Before Drop: false
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/binlogctl -cmd drainers
+./binlogctl -cmd drainers
 ```
 
 ```
@@ -434,7 +434,7 @@ Check Table Before Drop: false
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/binlogctl -cmd pumps
+./binlogctl -cmd pumps
 ```
 
 ```
@@ -447,7 +447,7 @@ Check Table Before Drop: false
 
 ```bash
 pkill drainer &&
-./bin/binlogctl -cmd drainers
+./binlogctl -cmd drainers
 ```
 
 预期输出：
@@ -465,8 +465,8 @@ pkill drainer &&
 - 使用 binlogctl 停止 Drainer，而不是结束进程：
 
     ```bash
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=drainers &&
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=pause-drainer --node-id=localhost.localdomain:8249
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=drainers &&
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=pause-drainer --node-id=localhost.localdomain:8249
     ```
 
 - 在启动 Pump **之前**先启动 Drainer。
@@ -474,7 +474,7 @@ pkill drainer &&
 - 在启动 PD 之后但在启动 Drainer 和 Pump 之前，使用 binlogctl 更新已暂定 Drainer 的状态。
 
     ```bash
-    ./bin/binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=update-drainer --node-id=localhost.localdomain:8249 --state=paused
+    ./binlogctl --pd-urls=http://127.0.0.1:2379 --cmd=update-drainer --node-id=localhost.localdomain:8249 --state=paused
     ```
 
 ## 清理
@@ -491,8 +491,8 @@ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1;
 
 ```
 [4]-  Done                    ./bin/tidb-server --config=tidb.toml &>tidb.out
-[5]+  Done                    ./bin/drainer --config=drainer.toml &>drainer.out
-[3]+  Done                    ./bin/pump --config=pump.toml &>pump.out
+[5]+  Done                    ./drainer --config=drainer.toml &>drainer.out
+[3]+  Done                    ./pump --config=pump.toml &>pump.out
 [2]+  Done                    ./bin/tikv-server --config=tikv.toml &>tikv.out
 [1]+  Done                    ./bin/pd-server --config=pd.toml &>pd.out
 ```
@@ -504,9 +504,9 @@ for p in tidb-server drainer pump tikv-server pd-server; do pkill "$p"; sleep 1;
 ```bash
 ./bin/pd-server --config=pd.toml &>pd.out &
 ./bin/tikv-server --config=tikv.toml &>tikv.out &
-./bin/drainer --config=drainer.toml &>drainer.out &
+./drainer --config=drainer.toml &>drainer.out &
 sleep 3
-./bin/pump --config=pump.toml &>pump.out &
+./pump --config=pump.toml &>pump.out &
 sleep 3
 ./bin/tidb-server --config=tidb.toml &>tidb.out &
 ```

--- a/tidb-binlog/tidb-binlog-reparo.md
+++ b/tidb-binlog/tidb-binlog-reparo.md
@@ -93,7 +93,7 @@ password = ""
 {{< copyable "shell-regular" >}}
 
 ```bash
-./bin/reparo -config reparo.toml
+./reparo -config reparo.toml
 ```
 
 > **注意：**

--- a/tidb-lightning/deploy-tidb-lightning.md
+++ b/tidb-lightning/deploy-tidb-lightning.md
@@ -42,7 +42,7 @@ aliases: ['/docs-cn/dev/tidb-lightning/deploy-tidb-lightning/','/docs-cn/dev/ref
 {{< copyable "shell-regular" >}}
 
 ```sh
-./bin/dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
+./dumpling -h 127.0.0.1 -P 3306 -u root -t 16 -F 256MB -B test -f 'test.t[12]' -o /data/my_database/
 ```
 
 其中：


### PR DESCRIPTION
### What is changed, added or deleted? (Required)
Remove `/bin` from some toolkit commands: `dm-master`, `dm-worker`, `dmctl`, `dumpling`, `sync_diff_inspector`, `binlogctl`, `pump`, `drainer`.
<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v6.1 (TiDB 6.1 versions)
- [x] v6.0 (TiDB 6.0 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)
- [ ] v4.0 (TiDB 4.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
