### PR TITLE
Not recommend setting tiflash logical split since 6.2

### DIFF
--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -157,7 +157,7 @@ delta_index_cache_size = 0
 
 [profiles.default]
     ## 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
-    ## 强烈不建议在 v6.2.0 以及后续版本将该配置项设置为 `true`。具体请参考已知问题 [#5576](https://github.com/pingcap/tiflash/issues/5576)。
+    ## 在 v6.2.0 以及后续版本，强烈建议保留默认值 `false`，不要将其修改为 `true`。具体请参考已知问题 [#5576](https://github.com/pingcap/tiflash/issues/5576)。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -157,7 +157,7 @@ delta_index_cache_size = 0
 
 [profiles.default]
     ## 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
-    ## 注意 logical split 在 v6.2.0 版本以及后续版本有已知问题 [#5576](https://github.com/pingcap/tiflash/issues/5576)，强烈不建议将该配置项设置为 `true`。
+    ## 强烈不建议在 v6.2.0 以及后续版本将该配置项设置为 `true`。具体请参考已知问题 [#5576](https://github.com/pingcap/tiflash/issues/5576)。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -156,8 +156,8 @@ delta_index_cache_size = 0
 [profiles]
 
 [profiles.default]
-    ## [deprecated] 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
-    ## 注意 6.2 版本 logical split 与其他 feature 存在兼容性问题，不建议将该配置项设置为 true。
+    ## 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
+    ## 注意 logical split 在 v6.2 版本以及后续版本有已知问题 (https://github.com/pingcap/tiflash/issues/5576)，强烈不建议将该配置项设置为 true。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -156,7 +156,8 @@ delta_index_cache_size = 0
 [profiles]
 
 [profiles.default]
-    ## 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。不建议修改默认选项。
+    ## [deprecated] 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。不建议修改默认选项。
+    ## 注意 6.2 版本 logical split 与其他 feature 存在兼容性问题，不建议在 6.2 及之后的版本将该配置项设置为 true。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制
@@ -177,10 +178,11 @@ delta_index_cache_size = 0
 
     ## 从 v5.4.0 引入，表示是否启用弹性线程池，这项功能可以显著提高 TiFlash 在高并发场景的 CPU 利用率。默认为 true。
     # enable_elastic_threadpool = true
-    # TiFlash 存储引擎的压缩算法，支持 LZ4、zstd 和 LZ4HC，大小写不敏感。默认使用 LZ4 算法。
+
+    ## TiFlash 存储引擎的压缩算法，支持 LZ4、zstd 和 LZ4HC，大小写不敏感。默认使用 LZ4 算法。
     dt_compression_method = "LZ4"
 
-    # TiFlash 存储引擎的压缩级别，默认为 1。如果 dt_compression_method 设置为 LZ4，推荐将该值设为 1；如果 dt_compression_method 设置为 zstd ，推荐将该值设为 -1 或 1，设置为 -1 的压缩率更小，但是读性能会更好；如果 dt_compression_method 设置为 LZ4HC，推荐将该值设为 9。
+    ## TiFlash 存储引擎的压缩级别，默认为 1。如果 dt_compression_method 设置为 LZ4，推荐将该值设为 1；如果 dt_compression_method 设置为 zstd ，推荐将该值设为 -1 或 1，设置为 -1 的压缩率更小，但是读性能会更好；如果 dt_compression_method 设置为 LZ4HC，推荐将该值设为 9。
     dt_compression_level = 1
 
     ## 从 v6.2.0 引入，使用线程池处理存储引擎的读请求。默认为 false。

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -157,7 +157,7 @@ delta_index_cache_size = 0
 
 [profiles.default]
     ## 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
-    ## 注意 logical split 在 v6.2 版本以及后续版本有已知问题 (https://github.com/pingcap/tiflash/issues/5576)，强烈不建议将该配置项设置为 true。
+    ## 注意 logical split 在 v6.2.0 版本以及后续版本有已知问题 [#5576](https://github.com/pingcap/tiflash/issues/5576)，强烈不建议将该配置项设置为 `true`。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制

--- a/tiflash/tiflash-configuration.md
+++ b/tiflash/tiflash-configuration.md
@@ -156,8 +156,8 @@ delta_index_cache_size = 0
 [profiles]
 
 [profiles.default]
-    ## [deprecated] 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。不建议修改默认选项。
-    ## 注意 6.2 版本 logical split 与其他 feature 存在兼容性问题，不建议在 6.2 及之后的版本将该配置项设置为 true。
+    ## [deprecated] 存储引擎的 segment 分裂是否使用逻辑分裂。使用逻辑分裂可以减小写放大，但是会造成一定程度的硬盘空间回收不及时。默认为 false。
+    ## 注意 6.2 版本 logical split 与其他 feature 存在兼容性问题，不建议将该配置项设置为 true。
     # dt_enable_logical_split = false
 
     ## 单次 coprocessor 查询过程中，对中间数据的内存限制，单位为 byte，默认为 0，表示不限制


### PR DESCRIPTION
Signed-off-by: JaySon-Huang <tshent@qq.com>

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->
According to https://github.com/pingcap/tiflash/issues/5576, if user deploys tiflash with explicit setting `profiles.default.dt_enable_logical_split = 1`.
After several logical split, PageStorage V3 will throw an exception for the third time logical split and make TiFlash crash.

Here we declare the config item to be deprecated

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v6.2 (TiDB 6.2 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
