### PR TITLE
Add an example for byte-threshold and region-cpu-overload-threshold-ratio adjustment

### DIFF
--- a/configure-load-base-split.md
+++ b/configure-load-base-split.md
@@ -47,9 +47,9 @@ Load Base Split 后的 Region 不会被迅速 Merge。一方面，PD 的 `MergeC
 
     ```sql
     # 设置 QPS 阈值为 1500
-    set config tikv split.qps-threshold=1500;
+    SET config tikv split.qps-threshold=1500;
     # 设置 Byte 阈值为 15 MiB (15 * 1024 * 1024)
-    set config tikv split.byte-threshold=15728640;
+    SET config tikv split.byte-threshold=15728640;
     ```
 
 - 通过 TiKV 修改，例如：

--- a/configure-load-base-split.md
+++ b/configure-load-base-split.md
@@ -46,7 +46,10 @@ Load Base Split 后的 Region 不会被迅速 Merge。一方面，PD 的 `MergeC
     {{< copyable "sql" >}}
 
     ```sql
-    set config tikv split.qps-threshold=3000
+    # 设置 QPS 阈值为 1500
+    set config tikv split.qps-threshold=1500;
+    # 设置 Byte 阈值为 15 MiB (15 * 1024 * 1024)
+    set config tikv split.byte-threshold=15728640;
     ```
 
 - 通过 TiKV 修改，例如：
@@ -54,7 +57,8 @@ Load Base Split 后的 Region 不会被迅速 Merge。一方面，PD 的 `MergeC
     {{< copyable "shell-regular" >}}
 
     ```shell
-    curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.qps-threshold":"3000"}'
+    curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.qps-threshold":"1500"}'
+    curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.byte-threshold":"15728640"}'
     ```
 
 同理，目前也有两种办法查看配置：

--- a/configure-load-base-split.md
+++ b/configure-load-base-split.md
@@ -50,6 +50,8 @@ Load Base Split 后的 Region 不会被迅速 Merge。一方面，PD 的 `MergeC
     SET config tikv split.qps-threshold=1500;
     # 设置 Byte 阈值为 15 MiB (15 * 1024 * 1024)
     SET config tikv split.byte-threshold=15728640;
+    # 设置 CPU 使用率阈值为 50%
+    SET config tikv split.region-cpu-overload-threshold-ratio=0.5;
     ```
 
 - 通过 TiKV 修改，例如：
@@ -59,6 +61,7 @@ Load Base Split 后的 Region 不会被迅速 Merge。一方面，PD 的 `MergeC
     ```shell
     curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.qps-threshold":"1500"}'
     curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.byte-threshold":"15728640"}'
+    curl -X POST "http://ip:status_port/config" -H "accept: application/json" -d '{"split.region-cpu-overload-threshold-ratio":"0.5"}'
     ```
 
 同理，目前也有两种办法查看配置：


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What is changed, added or deleted? (Required)

Add an example for the adjustment of `byte-threshold` and `region-cpu-overload-threshold-ratio` of the Load Base Split.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.3 (TiDB 6.3 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
