### PR TITLE
tidb: add warning message of drop table

### DIFF
--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -72,7 +72,22 @@ DROP TABLE IF EXISTS table_not_exists;
 ```
 
 ```
-Query OK, 0 rows affected (0.01 sec)
+Query OK, 0 rows affected, 1 warning (0.01 sec)
+```
+
+{{< copyable "sql" >}}
+
+```sql
+SHOW WARNINGS;
+```
+
+```
++-------+------+---------------------------------------+
+| Level | Code | Message                               |
++-------+------+---------------------------------------+
+| Note  | 1051 | Unknown table 'test.table_not_exists' |
++-------+------+---------------------------------------+
+1 row in set (0.01 sec)
 ```
 
 {{< copyable "sql" >}}
@@ -97,7 +112,6 @@ Query OK, 0 rows affected (0.23 sec)
 
 ## MySQL 兼容性
 
-* 在尝试删除不存在的表时，使用 `IF EXISTS` 删除表不会返回警告。[Issue #7867](https://github.com/pingcap/tidb/issues/7867)
 * 目前 `RESTRICT` 和 `CASCADE` 仅在语法上支持。
 
 ## 另请参阅

--- a/sql-statements/sql-statement-drop-table.md
+++ b/sql-statements/sql-statement-drop-table.md
@@ -75,8 +75,6 @@ DROP TABLE IF EXISTS table_not_exists;
 Query OK, 0 rows affected, 1 warning (0.01 sec)
 ```
 
-{{< copyable "sql" >}}
-
 ```sql
 SHOW WARNINGS;
 ```


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)
Fix a wrong description of `DROP TABLE IF EXISTS` warning message. The origin related issue is resolved before v4.0.0.

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v6.6 (TiDB 6.6 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
