### PR TITLE
multiple AZs in two regions: fix the topology example

### DIFF
--- a/three-data-centers-in-two-cities-deployment.md
+++ b/three-data-centers-in-two-cities-deployment.md
@@ -63,7 +63,7 @@ AZ1 的 rac1 机架中，一台服务器部署了 TiDB 和 PD 服务，另外两
 
 以下为一个 `tiup topology.yaml` 文件示例：
 
-```
+```yaml
 # # Global variables are applied to all deployments and used as the default value of
 # # the deployments if a specific deployment value is missing.
 global:
@@ -76,7 +76,7 @@ server_configs:
   tikv:
     server.grpc-compression-type: gzip
   pd:
-    replication.location-labels:  ["dc","zone","rack","host"]
+    replication.location-labels:  ["az","replication zone","rack","host"]
 
 pd_servers:
   - host: 10.63.10.10
@@ -134,7 +134,7 @@ alertmanager_servers:
 
 PD 设置中添加 TiKV label 的等级配置。
 
-```
+```yaml
 server_configs:
   pd:
     replication.location-labels:  ["az","replication zone","rack","host"]
@@ -142,7 +142,7 @@ server_configs:
 
 tikv_servers 设置基于 TiKV 真实物理部署位置的 Label 信息，方便 PD 进行全局管理和调度。
 
-```
+```yaml
 tikv_servers:
   - host: 10.63.10.30
     config:
@@ -167,13 +167,13 @@ tikv_servers:
 
 - 启用 TiKV gRPC 消息压缩。由于需要在网络中传输集群数据，可开启 gRPC 消息压缩，降低网络流量。
 
-    ```
+    ```yaml
     server.grpc-compression-type: gzip
     ```
 
 - 优化跨区域 AZ3 的 TiKV 节点网络，修改 TiKV 的如下参数，拉长跨区域副本参与选举的时间，避免跨区域 TiKV 中的副本参与 Raft 选举。
 
-    ```
+    ```yaml
     raftstore.raft-min-election-timeout-ticks: 1000
     raftstore.raft-max-election-timeout-ticks: 1200
     ```
@@ -187,7 +187,7 @@ tikv_servers:
 - 禁止向跨区域 AZ 调度 Raft Leader，当 Raft Leader 在跨区域 AZ 时，会造成不必要的本区域 AZ 与远程 AZ 间的网络消耗，同时，网络带宽和延迟也会对 TiDB 的集群性能产生影响。
 
     ```
-    config set label-property reject-leader dc 3
+    config set label-property reject-leader az 3
     ```
 
     > **注意：**

--- a/two-data-centers-in-one-city-deployment.md
+++ b/two-data-centers-in-one-city-deployment.md
@@ -38,7 +38,7 @@ TiDB 通常采用多 AZ 部署方案保证集群高可用和容灾能力。多 A
 
 以下 `tiup topology.yaml` 示例拓扑文件为单区域双 AZ 典型的拓扑配置：
 
-```
+```yaml
 # # Global variables are applied to all deployments and used as the default value of
 # # the deployments if a specific deployment value is missing.
 global:
@@ -48,7 +48,7 @@ global:
   data_dir: "/data/tidb_cluster/tidb-data"
 server_configs:
   pd:
-    replication.location-labels:  ["az","rack","host"]
+    replication.location-labels: ["az","rack","host"]
 pd_servers:
   - host: 10.63.10.10
     name: "pd-10"


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The `replication.location-labels` configuration in `three-data-centers-in-two-cities-deployment.md` is inaccurate.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.4 (TiDB 6.4 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
