### PR TITLE
ci: remove assignees in Links, update the deprecated set-output command

### DIFF
--- a/.github/workflows/dispatch.yml
+++ b/.github/workflows/dispatch.yml
@@ -17,7 +17,7 @@ jobs:
         id: extract
         shell: bash
         run: |
-          echo "::set-output name=sha::$(sha=${{ github.sha }}; echo ${sha:0:6})"
+          echo "sha=$(sha=${{ github.sha }}; echo ${sha:0:6})" >> $GITHUB_OUTPUT
 
       - name: trigger docs-staging workflow
         run: |

--- a/.github/workflows/link-fail-fast.yaml
+++ b/.github/workflows/link-fail-fast.yaml
@@ -15,7 +15,7 @@ jobs:
         id: changed-files
         run: |
           CHANGED_FILES=$(git diff-tree --name-only --diff-filter 'AM' -r HEAD^1 HEAD -- "*.md" | sed -z "s/\n$//;s/\n/' '/g")
-          echo "::set-output name=all_changed_files::${CHANGED_FILES}"
+          echo "all_changed_files=${CHANGED_FILES}" >> $GITHUB_OUTPUT
 
       - name: Download Exclude Path
         run: |

--- a/.github/workflows/link.yaml
+++ b/.github/workflows/link.yaml
@@ -26,11 +26,10 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Create Issue From File
-        uses: peter-evans/create-issue-from-file@v3
+        uses: peter-evans/create-issue-from-file@v4
         with:
           title: Broken Link Detected
           content-filepath: out.md
-          assignees: TomShawn
 
 #      - name: Fail if there were link errors
 #        run: exit ${{ steps.lychee.outputs.exit_code }}


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Remove `assignees` in the Create Issue From File step. 
- Close #12060 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [x] v5.2 (TiDB 5.2 versions)
- [x] v5.1 (TiDB 5.1 versions)
- [x] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/13034
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
