### PR TITLE
v6.5: modify default value descriptions for enable-partition-separator

### DIFF
--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表同步数据到存储服务时 TiCDC 默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步数据到存储服务时默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个 partition 的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步数据到存储服务时默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步数据到存储服务时默认会将一张表中各个 partition 的数据分不同的目录来存储。建议保持该参数为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步数据到存储服务时默认会将一张表中各个 partition 的数据分不同的目录来存储。建议保持该参数为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个 partition 的数据分不同的目录来存储。建议保持该参数为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决 TiCDC 同步分区表到存储服务时可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决同步分区表到存储服务时可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决下游分区表可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决 TiCDC 同步分区表到存储服务时可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- TiCDC 配置参数 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表同步数据到存储服务时 TiCDC 默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表同步数据到存储服务时 TiCDC 默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决下游分区表可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个分区的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,7 +17,7 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
-- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个 partition 的数据分不同的目录来存储。建议保持该参数为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+- 为了解决分区表场景可能丢数据的问题，TiCDC 配置项 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表 TiCDC 同步分区表到存储服务时默认会将表中各个 partition 的数据分不同的目录来存储。建议保持该配置项为 `true` 以避免该问题。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
 
 ## 改进提升
 

--- a/releases/release-6.5.2.md
+++ b/releases/release-6.5.2.md
@@ -17,6 +17,8 @@ TiDB 版本：6.5.2
 
     在升级 TiCDC 集群到 v6.5.2 或更高的 v6.5.x 版本时，如果使用 Avro 同步的表包含 `FLOAT` 类型数据，请在升级前手动调整 Confluent Schema Registry 的兼容性策略为 `None`，使 changefeed 能够成功更新 schema。否则，在升级之后 changefeed 将无法更新 schema 并进入错误状态。
 
+- TiCDC 配置参数 [`sink.enable-partition-separator`](/ticdc/ticdc-changefeed-config.md#ticdc-changefeed-配置文件说明) 默认值从 `false` 修改为 `true`，代表同步数据到存储服务时 TiCDC 默认将一张表中各个 partition 的数据分不同的目录来存储。[#8581](https://github.com/pingcap/tiflow/issues/8581) @[CharlesCheung96](https://github.com/CharlesCheung96)
+
 ## 改进提升
 
 + TiDB

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -110,7 +110,7 @@ protocol = "canal-json"
 terminator = ''
 # 文件路径的日期分隔类型。可选类型有 `none`、`year`、`month` 和 `day`。默认值为 `none`，即不使用日期分隔。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 date-separator = 'none'
-# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。从 v6.5.2 起，默认值修改为 true。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
+# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。在 v6.5.2 或更高的 v6.5.x 版本中，默认值为 true。使用示例详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 enable-partition-separator = true
 
 # 从 v6.5.0 开始，TiCDC 支持以 CSV 格式将数据变更记录保存至存储服务中，在 MQ 和 MySQL 类 sink 中无需设置。

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -110,7 +110,7 @@ protocol = "canal-json"
 terminator = ''
 # 文件路径的日期分隔类型。可选类型有 `none`、`year`、`month` 和 `day`。默认值为 `none`，即不使用日期分隔。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 date-separator = 'none'
-# 是否使用 partition 作为分隔字符串。默认值为 true，即一张表中各个 partition 的数据会分不同的目录来存储。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
+# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。从 v6.5.2 起，默认值修改为 true。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 enable-partition-separator = true
 
 # 从 v6.5.0 开始，TiCDC 支持以 CSV 格式将数据变更记录保存至存储服务中，在 MQ 和 MySQL 类 sink 中无需设置。

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -110,7 +110,7 @@ protocol = "canal-json"
 terminator = ''
 # 文件路径的日期分隔类型。可选类型有 `none`、`year`、`month` 和 `day`。默认值为 `none`，即不使用日期分隔。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 date-separator = 'none'
-# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。在 v6.5.2 或更高的 v6.5.x 版本中，默认值为 true。使用示例详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
+# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。在 v6.5.2 或更高的 v6.5.x 版本中，默认值为 true。建议保持该配置项为 true 以避免分区表场景可能丢数据的问题 <https://github.com/pingcap/tiflow/issues/8581>。使用示例详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 enable-partition-separator = true
 
 # 从 v6.5.0 开始，TiCDC 支持以 CSV 格式将数据变更记录保存至存储服务中，在 MQ 和 MySQL 类 sink 中无需设置。

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -110,7 +110,7 @@ protocol = "canal-json"
 terminator = ''
 # 文件路径的日期分隔类型。可选类型有 `none`、`year`、`month` 和 `day`。默认值为 `none`，即不使用日期分隔。详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 date-separator = 'none'
-# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。在 v6.5.2 或更高的 v6.5.x 版本中，默认值为 true。建议保持该配置项为 true 以避免分区表场景可能丢数据的问题 <https://github.com/pingcap/tiflow/issues/8581>。使用示例详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
+# 是否使用 partition 作为分隔字符串，将一张表中各个 partition 的数据分不同的目录来存储。在 v6.5.0 和 v6.5.1 中，默认值为 false。在 v6.5.2 或更高的 v6.5.x 版本中，默认值为 true。建议保持该配置项为 true 以避免下游分区表可能丢数据的问题 <https://github.com/pingcap/tiflow/issues/8581>。使用示例详见 <https://docs.pingcap.com/zh/tidb/dev/ticdc-sink-to-cloud-storage#数据变更记录>。
 enable-partition-separator = true
 
 # 从 v6.5.0 开始，TiCDC 支持以 CSV 格式将数据变更记录保存至存储服务中，在 MQ 和 MySQL 类 sink 中无需设置。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

Modify the default value of `enable-partition-separator` for v6.5.2.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/tiflow/pull/8779

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
