### PR TITLE
tiup: update the default value of transfer-timeout from 300 to 600

### DIFF
--- a/dm/maintain-dm-using-tiup.md
+++ b/dm/maintain-dm-using-tiup.md
@@ -242,7 +242,7 @@ Flags:
   -N, --node strings           Specify the nodes
       --overwrite              Use this package in the future scale-out operations
   -R, --role strings           Specify the role
-      --transfer-timeout int   Timeout in seconds when transferring dm-master leaders (default 300)
+      --transfer-timeout int   Timeout in seconds when transferring dm-master leaders (default 600)
 
 Global Flags:
       --native-ssh         Use the native SSH client installed on local system instead of the build-in one.

--- a/tiup/tiup-component-cluster-patch.md
+++ b/tiup/tiup-component-cluster-patch.md
@@ -37,7 +37,7 @@ tiup cluster patch <cluster-name> <package-path> [flags]
 - 数据类型：`BOOLEAN`
 - 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
 
-### --transfer-timeout（uint，默认 300）
+### --transfer-timeout（uint，默认 600）
 
 在重启 PD 或 TiKV 时，会先将被重启节点的 leader 迁移到其他节点，迁移过程会需要一定时间，可以通过设置 `--transfer-timeout` 设置最长等待时间（单位为秒），超时之后会跳过等待直接重启服务。
 

--- a/tiup/tiup-component-cluster-reload.md
+++ b/tiup/tiup-component-cluster-reload.md
@@ -22,7 +22,7 @@ tiup cluster reload <cluster-name> [flags]
 - 数据类型：`BOOLEAN`
 - 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
 
-### --transfer-timeout（uint，默认 300）
+### --transfer-timeout（uint，默认 600）
 
 在重启 PD 或 TiKV 时，会先将被重启节点的 leader 迁移到其他节点，迁移过程会需要一定时间，可以通过设置 `--transfer-timeout` 设置最长等待时间（单位为秒），超时之后会跳过等待直接重启服务。
 

--- a/tiup/tiup-component-cluster-scale-in.md
+++ b/tiup/tiup-component-cluster-scale-in.md
@@ -45,7 +45,7 @@ tiup cluster scale-in <cluster-name> [flags]
 >
 > 使用该选项强制移除正在服务和下线中的 TiKV / TiFlash 节点时，这些节点会被直接删除，不等待数据调度完成，因此这个场景下，数据丢失风险非常大。不建议对未宕机的节点使用该选项。如果元数据所在的 Region 发生数据丢失，整个集群将不可用且无法恢复。
 
-### --transfer-timeout（uint，默认 300）
+### --transfer-timeout（uint，默认 600）
 
 在缩容 PD 或 TiKV 时，会先将被缩容节点的 leader 迁移到其他节点，迁移过程会需要一定时间，可以通过设置 `--transfer-timeout` 设置最长等待时间（单位为秒），超时之后会跳过等待直接缩容服务。
 

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -27,7 +27,7 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 > 
 > 对正在提供服务的集群强制升级可能导致集群服务不可用。对于未启动的集群，升级成功后会自动启动集群。
 
-### --transfer-timeout（uint，默认 300）
+### --transfer-timeout（uint，默认 600）
 
 在升级 PD 或 TiKV 时，会先将被升级节点的 leader 迁移到其他节点，迁移过程会需要一定时间，可以通过设置 `--transfer-timeout` 设置最长等待时间（单位为秒），超时之后会跳过等待直接升级服务。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The default value of transfer-timeout is `600`.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/tiup/pull/1972
 
### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
