### PR TITLE
Revert "Add description on `admin pause ddl jobs` and `admin resume ddl jobs`"

### DIFF
--- a/basic-features.md
+++ b/basic-features.md
@@ -124,7 +124,6 @@ aliases: ['/docs-cn/dev/basic-features/','/docs-cn/dev/experimental-features-4.0
 | [添加索引加速](/system-variables.md#tidb_ddl_enable_fast_reorg-从-v630-版本开始引入) | Y | Y | N | N | N | N | N | N | N |
 | [元数据锁](/metadata-lock.md) | Y | Y | N | N | N | N | N | N | N |
 | [`FLASHBACK CLUSTER TO TIMESTAMP`](/sql-statements/sql-statement-flashback-to-timestamp.md) | Y | Y | N | N | N | N | N | N | N |
-| [暂停/恢复 DDL](/ddl-introduction.md#ddl-相关的命令介绍) | E | N | N | N | N | N | N | N | N |
 
 ## 事务
 

--- a/ddl-introduction.md
+++ b/ddl-introduction.md
@@ -176,15 +176,7 @@ absent -> delete only -> write only -> write reorg -> public
 
 - `ADMIN CANCEL DDL JOBS job_id [, job_id]`：用于取消已经提交但未执行完成的 DDL 任务。取消完成后，执行 DDL 任务的 SQL 语句会返回 `ERROR 8214 (HY000): Cancelled DDL job` 错误。
 
-    取消一个已经执行完成的 DDL 任务会在 `RESULT` 列看到 `DDL Job:90 not found` 的错误，表示该任务已从 DDL 等待队列中被移除。
-
-- `ADMIN PAUSE DDL JOBS job_id [, job_id]`：用于暂停正在执行的 DDL 任务。执行该命令后，执行 DDL 任务的 SQL 语句体现为正在执行，后台任务暂停执行。（实验特性）
-
-    只有处于执行中或仍在等待中的 DDL 任务可以暂停，否则会在 `RESULT` 列看到 `Job 3 can't be paused now`。
-
-- `ADMIN RESUME DDL JOBS job_id [, job_id]`：用于恢复已被暂停的 DDL 任务。执行该命令后，执行 DDL 任务的 SQL 语句体现为正在执行，后台任务正常执行。（实验特性）
-
-    你只能对暂停状态的 DDL 任务进行恢复操作，否则会在 `RESULT` 列看到 `Job 3 can't be resumed`。
+    取消一个已经执行完成的 DDL 任务会在 RESULT 列看到 `DDL Job:90 not found` 的错误，表示该任务已从 DDL 等待队列中被移除。
 
 ## 常见问题
 

--- a/ddl-introduction.md
+++ b/ddl-introduction.md
@@ -176,7 +176,7 @@ absent -> delete only -> write only -> write reorg -> public
 
 - `ADMIN CANCEL DDL JOBS job_id [, job_id]`：用于取消已经提交但未执行完成的 DDL 任务。取消完成后，执行 DDL 任务的 SQL 语句会返回 `ERROR 8214 (HY000): Cancelled DDL job` 错误。
 
-    取消一个已经执行完成的 DDL 任务会在 RESULT 列看到 `DDL Job:90 not found` 的错误，表示该任务已从 DDL 等待队列中被移除。
+    取消一个已经执行完成的 DDL 任务会在 `RESULT` 列看到 `DDL Job:90 not found` 的错误，表示该任务已从 DDL 等待队列中被移除。
 
 ## 常见问题
 

--- a/releases/release-7.1.0.md
+++ b/releases/release-7.1.0.md
@@ -154,21 +154,6 @@ TiDB 版本：7.1.0 (upcoming)
 
     更多信息，请参考[用户文档](/generated-columns.md)。
 
-### 数据库管理
-
-* DDL 任务支持暂停和恢复操作（实验特性）[#18015](https://github.com/pingcap/tidb/issues/18015) @[godouxm](https://github.com/godouxm)
-
-    TiDB v7.1.0 之前的版本中，当 DDL 任务执行期间遇到业务高峰时间点时，为了减少对业务的影响，只能手动取消 DDL 任务。TiDB v7.1.0 引入了 DDL 任务的暂停和恢复功能，你可以在高峰时间点暂停 DDL 任务，等到业务高峰时间结束后再恢复 DDL 任务，从而避免了 DDL 操作对业务负载的影响。
-
-    例如，可以通过如下 `ADMIN PAUSE DDL JOBS` 或 `ADMIN RESUME DDL JOBS` 语句暂停或者恢复多个 DDL 任务：
-
-    ```sql
-    ADMIN PAUSE DDL JOBS 1,2;
-    ADMIN RESUME DDL JOBS 1,2;
-    ```
-
-    更多信息，请参考[用户文档](/ddl-introduction.md#ddl-相关的命令介绍)。
-
 ### 可观测性
 
 * 增加优化器诊断信息 [#43122](https://github.com/pingcap/tidb/issues/43122) @[time-and-fate](https://github.com/time-and-fate)

--- a/smooth-upgrade-tidb.md
+++ b/smooth-upgrade-tidb.md
@@ -43,7 +43,7 @@ TiDB 引入平滑升级功能前，对于升级过程中的 DDL 操作有如下�
 
     * 对系统表（`mysql.*`、`information_schema.*`、`performance_schema.*`、`metrics_schema.*`）进行 DDL 操作。
 
-    * 执行手动取消、暂停、恢复 DDL job 操作：`ADMIN CANCEL/PAUSE/RESUME DDL JOBS job_id [, job_id] ...;`。
+    * 执行手动取消 DDL job 操作：`ADMIN CANCEL DDL JOBS job_id [, job_id] ...;`。
 
     * 导入数据。
 


### PR DESCRIPTION
Reverts pingcap/docs-cn#13731

Remove `ADMIN PAUSE DDL JOBS job_id [, job_id]` and `ADMIN RESUME DDL JOBS job_id [, job_id]` in TiDB v7.1.0