### PR TITLE
ticdc: remove only-output-updated-columns from v7.0 and earlier versions

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -162,11 +162,6 @@ enable-partition-separator = true
 # 注意：该参数只有当下游为消息队列时，才会生效。
 # enable-kafka-sink-v2 = false
 
-# 是否只向下游同步有内容更新的列。
-# 默认值为 false。
-# 注意：该参数只有当下游为消息队列，并且使用 Open Protocol 或 Canal-JSON 时，才会生效。
-# only-output-updated-columns = false
-
 # 从 v6.5.0 开始，TiCDC 支持以 CSV 格式将数据变更记录保存至存储服务中，在 MQ 和 MySQL 类 sink 中无需设置。
 [sink.csv]
 # 字段之间的分隔符。必须为 ASCII 字符，默认值为 `,`。


### PR DESCRIPTION

### What is changed, added or deleted? (Required)

TiDB v7.1.0 introduces only-output-updated-columns. This PR removes only-output-updated-columns from v7.0 and earlier versions.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
