### PR TITLE
select: Add tablesample

### DIFF
--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -110,7 +110,7 @@ TableSampleOpt ::=
 |`Window window_definition`| 窗口函数的相关语法，用来进行一些分析型计算的操作，详情可见[窗口函数](/functions-and-operators/window-functions.md)|
 |`FOR UPDATE` | 对查询结果集所有行上锁（对于在查询条件内，但是不在结果集的行，将不会加锁，如事务启动后由其他事务写入的行），以监测其他事务对这些的并发修改。使用[乐观事务模型](/optimistic-transaction.md)时，语句执行期间不会检测锁，因此，不会像 PostgreSQL 之类的数据库一样，在当前事务结束前阻止其他事务执行 `UPDATE`、`DELETE` 和 `SELECT FOR UPDATE`。在事务的提交阶段 `SELECT FOR UPDATE` 读到的行，也会进行两阶段提交，因此，它们也可以参与事务冲突检测。如发生写入冲突，那么包含 `SELECT FOR UPDATE` 语句的事务会提交失败。如果没有冲突，事务将成功提交，当提交结束时，这些被加锁的行，会产生一个新版本，可以让其他尚未提交的事务，在将来提交时发现写入冲突。若使用悲观事务，则行为与其他数据库基本相同，不一致之处参考[和 MySQL InnoDB 的差异](/pessimistic-transaction.md#和-mysql-innodb-的差异)。TiDB 支持 `FOR UPDATE NOWAIT` 语法，详情可见 [TiDB 中悲观事务模式的行为](/pessimistic-transaction.md#悲观事务模式的行为)。|
 |`LOCK IN SHARE MODE` | TiDB 出于兼容性解析这个语法，但是不做任何处理|
-|`TABLESAMPLE`| 从表中获取一些行的样本。|
+|`TABLESAMPLE`| 从表中获取一些行的样本数据。|
 
 ## 示例
 

--- a/sql-statements/sql-statement-select.md
+++ b/sql-statements/sql-statement-select.md
@@ -33,16 +33,12 @@ aliases: ['/docs-cn/dev/sql-statements/sql-statement-select/','/docs-cn/dev/refe
 **TableRefsClause:**
 
 ```ebnf+diagram
-TableRefsClause ::= 
+TableRefsClause ::=
     TableRef AsOfClause? ( ',' TableRef AsOfClause? )*
 
 AsOfClause ::=
     'AS' 'OF' 'TIMESTAMP' Expression
 ```
-
-**WhereClauseOptional:**
-
-![WhereClauseOptional](/media/sqlgram/WhereClauseOptional.png)
 
 **SelectStmtGroup:**
 
@@ -75,7 +71,7 @@ AsOfClause ::=
 **SelectLockOpt:**
 
 ```ebnf+diagram
-SelectLockOpt ::= 
+SelectLockOpt ::=
     ( ( 'FOR' 'UPDATE' ( 'OF' TableList )? 'NOWAIT'? )
 |   ( 'LOCK' 'IN' 'SHARE' 'MODE' ) )?
 
@@ -86,6 +82,13 @@ TableList ::=
 **WindowClauseOptional**
 
 ![WindowClauseOptional](/media/sqlgram/WindowClauseOptional.png)
+
+**TableSampleOpt**
+
+```ebnf+diagram
+TableSampleOpt ::=
+    'TABLESAMPLE' 'REGIONS()'
+```
 
 ## 语法元素说明
 
@@ -107,6 +110,7 @@ TableList ::=
 |`Window window_definition`| 窗口函数的相关语法，用来进行一些分析型计算的操作，详情可见[窗口函数](/functions-and-operators/window-functions.md)|
 |`FOR UPDATE` | 对查询结果集所有行上锁（对于在查询条件内，但是不在结果集的行，将不会加锁，如事务启动后由其他事务写入的行），以监测其他事务对这些的并发修改。使用[乐观事务模型](/optimistic-transaction.md)时，语句执行期间不会检测锁，因此，不会像 PostgreSQL 之类的数据库一样，在当前事务结束前阻止其他事务执行 `UPDATE`、`DELETE` 和 `SELECT FOR UPDATE`。在事务的提交阶段 `SELECT FOR UPDATE` 读到的行，也会进行两阶段提交，因此，它们也可以参与事务冲突检测。如发生写入冲突，那么包含 `SELECT FOR UPDATE` 语句的事务会提交失败。如果没有冲突，事务将成功提交，当提交结束时，这些被加锁的行，会产生一个新版本，可以让其他尚未提交的事务，在将来提交时发现写入冲突。若使用悲观事务，则行为与其他数据库基本相同，不一致之处参考[和 MySQL InnoDB 的差异](/pessimistic-transaction.md#和-mysql-innodb-的差异)。TiDB 支持 `FOR UPDATE NOWAIT` 语法，详情可见 [TiDB 中悲观事务模式的行为](/pessimistic-transaction.md#悲观事务模式的行为)。|
 |`LOCK IN SHARE MODE` | TiDB 出于兼容性解析这个语法，但是不做任何处理|
+|`TABLESAMPLE`| 从表中获取一些行的样本。|
 
 ## 示例
 
@@ -150,11 +154,32 @@ SELECT * FROM t1;
 5 rows in set (0.00 sec)
 ```
 
+下面这个例子使用 `tiup bench tpcc prepare` 生成的数据，其中第一个查询展示了 `TABLESAMPLE` 的用法。
+
+```sql
+mysql> SELECT AVG(s_quantity), COUNT(s_quantity) FROM stock TABLESAMPLE REGIONS();
++-----------------+-------------------+
+| AVG(s_quantity) | COUNT(s_quantity) |
++-----------------+-------------------+
+|         59.5000 |                 4 |
++-----------------+-------------------+
+1 row in set (0.00 sec)
+
+mysql> SELECT AVG(s_quantity), COUNT(s_quantity) FROM stock;
++-----------------+-------------------+
+| AVG(s_quantity) | COUNT(s_quantity) |
++-----------------+-------------------+
+|         54.9729 |           1000000 |
++-----------------+-------------------+
+1 row in set (0.52 sec)
+```
+
 ## MySQL 兼容性
 
 - 不支持 `SELECT ... INTO @variable` 语法。
 - 不支持 `SELECT ... GROUP BY ... WITH ROLLUP` 语法。
 - 不支持 MySQL 5.7 中支持的 `SELECT .. GROUP BY expr` 语法，而是匹配 MySQL 8.0 的行为，不按照默认的顺序进行排序。
+- `SELECT ... TABLESAMPLE ...` 是 TiDB 的扩展语法，MySQL 不支持该语法。
 
 ## 另请参阅
 

--- a/temp.md
+++ b/temp.md
@@ -1,0 +1,1 @@
+This is a test file.

--- a/temp.md
+++ b/temp.md
@@ -1,1 +1,0 @@
-This is a test file.


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Closes #5915



<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.4 (TiDB 6.4 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/12979
- Other reference link(s):
    - https://github.com/pingcap/tidb/issues/20567
    - https://bugs.mysql.com/bug.php?id=92759

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch



### Example

```
sql> SELECT * FROM item TABLESAMPLE REGIONS();
+------+---------+-------------------------+---------+------------------------------------------+
| i_id | i_im_id | i_name                  | i_price | i_data                                   |
+------+---------+-------------------------+---------+------------------------------------------+
|    1 |    6138 | 1Md6YJgZCYlcpfBkWmOJzmS |   11.38 | 99AZzeYO7GIi0Q9bgufHVwXVzMYxdIOa3pr3Guia |
+------+---------+-------------------------+---------+------------------------------------------+
1 row in set (0.0014 sec)
```