### PR TITLE
tikv: fixed some description about `--db` and `compact-cluster` 

### DIFF
--- a/tikv-control.md
+++ b/tikv-control.md
@@ -335,7 +335,10 @@ middle_key_by_approximate_size:
 
 ### 手动 compact 整个 TiKV 集群的数据
 
-`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是使用 `compact-cluster` 命令时，compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定单个 TiKV。
+`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别如下：
+
+- 使用 `compact-cluster` 命令时，通过 `--pd` 指定 PD 所在的地址来确定 compact 的目标。
+- 使用 `compact` 命令时，通过 `--data-dir` 或者 `--host` 指定单个 TiKV。
 
 ### 设置一个 Region 副本为 tombstone 状态
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -335,7 +335,7 @@ middle_key_by_approximate_size:
 
 ### 手动 compact 整个 TiKV 集群的数据
 
-`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是 compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定单个 TiKV。
+`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是使用 `compact-cluster` 命令时，compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定单个 TiKV。
 
 ### 设置一个 Region 副本为 tombstone 状态
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -338,7 +338,7 @@ middle_key_by_approximate_size:
 
 `compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别如下：
 
-- 使用 `compact-cluster` 命令时，通过 `--pd` 指定 PD 所在的地址来确定 compact 的目标。
+- 使用 `compact-cluster` 命令时，通过 `--pd` 指定 PD 所在的地址，以便 `tikv-ctl` 可以找到集群中的所有 TiKV 节点作为 compact 目标。
 - 使用 `compact` 命令时，通过 `--data-dir` 或者 `--host` 指定单个 TiKV。
 
 ### 设置一个 Region 副本为 tombstone 状态

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -339,7 +339,7 @@ middle_key_by_approximate_size:
 `compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别如下：
 
 - 使用 `compact-cluster` 命令时，通过 `--pd` 指定 PD 所在的地址，以便 `tikv-ctl` 可以找到集群中的所有 TiKV 节点作为 compact 目标。
-- 使用 `compact` 命令时，通过 `--data-dir` 或者 `--host` 指定单个 TiKV。
+- 使用 `compact` 命令时，通过 `--data-dir` 或者 `--host` 指定单个 TiKV 作为 compact 目标。
 
 ### 设置一个 Region 副本为 tombstone 状态
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -324,18 +324,18 @@ middle_key_by_approximate_size:
 - 在本地模式 compact data，执行如下命令：
 
     ```shell
-    tikv-ctl --data-dir /path/to/tikv compact --db kv
+    tikv-ctl --data-dir /path/to/tikv compact -d kv
     ```
 
 - 在远程模式 compact data，执行如下命令：
 
     ```shell
-    tikv-ctl --host ip:port compact --db kv
+    tikv-ctl --host ip:port compact -d kv
     ```
 
 ### 手动 compact 整个 TiKV 集群的数据
 
-`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是 compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定的单个 TiKV。
+`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是 compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定单个 TiKV。
 
 ### 设置一个 Region 副本为 tombstone 状态
 

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -314,7 +314,8 @@ middle_key_by_approximate_size:
 
 - `--from` 和 `--to` 选项以 escaped raw key 形式指定 compact 的范围。如果没有设置，表示 compact 整个 TiKV。
 - `--region` 选项指定 compact Region 的范围。如果设置，则 `--from` 和 `--to` 选项会被忽略。
-- `-d` 选项可以指定要 compact 的 RocksDB，可选值为 `kv` 和 `raft`。
+- `-c` 选项指定 column family 名称，默认值为 `default`，可选值为 `default`、`lock` 和 `write`。
+- `-d` 选项指定要 compact 的 RocksDB，默认值为 `kv`，可选值为 `kv` 和 `raft`。
 - `--threads` 选项可以指定 compact 的并发数，默认值是 8。一般来说，并发数越大，compact 的速度越快，但是也会对服务造成影响，所以需要根据情况选择合适的并发数。
 - `--bottommost` 选项可以指定 compact 是否包括最下层的文件。可选值为 `default`、`skip` 和 `force`，默认为 `default`。
     - `default` 表示只有开启了 Compaction Filter 时 compact 才会包括最下层文件。

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -314,7 +314,7 @@ middle_key_by_approximate_size:
 
 - `--from` 和 `--to` 选项以 escaped raw key 形式指定 compact 的范围。如果没有设置，表示 compact 整个 TiKV。
 - `--region` 选项指定 compact Region 的范围。如果设置，则 `--from` 和 `--to` 选项会被忽略。
-- `--db` 选项可以指定要 compact 的 RocksDB，可选值为 `kv` 和 `raft`。
+- `-d` 选项可以指定要 compact 的 RocksDB，可选值为 `kv` 和 `raft`。
 - `--threads` 选项可以指定 compact 的并发数，默认值是 8。一般来说，并发数越大，compact 的速度越快，但是也会对服务造成影响，所以需要根据情况选择合适的并发数。
 - `--bottommost` 选项可以指定 compact 是否包括最下层的文件。可选值为 `default`、`skip` 和 `force`，默认为 `default`。
     - `default` 表示只有开启了 Compaction Filter 时 compact 才会包括最下层文件。
@@ -335,7 +335,7 @@ middle_key_by_approximate_size:
 
 ### 手动 compact 整个 TiKV 集群的数据
 
-`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样。
+`compact-cluster` 命令可以对整个 TiKV 集群进行手动 compact。该命令参数的含义和使用与 `compact` 命令一样，唯一的区别是 compact 的目标要通过 `--pd` 指定 PD 所在的地址来确定，而不是用 `--data-dir` 或者 `--host` 指定的单个 TiKV。
 
 ### 设置一个 Region 副本为 tombstone 状态
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed [**Contributor License Agreement**](https://cla-assistant.io/pingcap/docs-cn) that's required for repo owners to accept my contribution.

### What is changed, added or deleted? (Required)

This PR have changed the `--db` option in `compact` and `compact-cluster` to `-d`, due to an unexpected omit of `long` opt <del>when migrating to `structopt`</del>, `--db` is unavailable for a long time.

This PR also explicitly announce that `compact-cluster` needs to specify the pd server instead of individual TiKV nodes.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v7.4 (TiDB 7.4 versions)
- [x] v7.3 (TiDB 7.3 versions)
- [x] v7.2 (TiDB 7.2 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v7.0 (TiDB 7.0 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [x] v5.4 (TiDB 5.4 versions)
- [x] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

https://github.com/tikv/tikv/pull/10837
<del>This PR has accidentally removed the `--db` option... I'm not sure whether we need to fix it. But anyway let's change the document to make it safer.</del>
It seems the previous commit didn't enable the long option too... Perhaps the history of the lost long opt is even longer...

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
