### PR TITLE
Document what ADMIN CHECK does

### DIFF
--- a/sql-statements/sql-statement-admin-check-table-index.md
+++ b/sql-statements/sql-statement-admin-check-table-index.md
@@ -5,7 +5,23 @@ summary: TiDB 数据库中 ADMIN CHECK [TABLE|INDEX] 的使用概况。
 
 # ADMIN CHECK [TABLE|INDEX]
 
-`ADMIN CHECK [TABLE|INDEX]` 语句用于校验表中数据和对应索引的一致性，不支持校验[外键约束](/foreign-key.md)。
+`ADMIN CHECK [TABLE|INDEX]` 语句用于校验表中数据和对应索引的一致性。
+
+该语句不支持：
+
+- 校验[外键约束](/foreign-key.md)。
+- 当使用[聚簇索引](/clustered-indexes.md)时，校验主键索引。
+
+如果执行 `ADMIN CHECK [TABLE|INDEX]` 发现任何问题，你可以删除并重新创建索引来解决。如果问题仍未解决，你可以在 GitHub 上提 [issue](https://github.com/pingcap/tidb/issues/new/choose) 反馈。
+
+## 原理
+
+`ADMIN CHECK TABLE` 语句执行以下步骤来校验表：
+
+1. 对每个索引，检查索引中的记录数是否与表中的记录数一致。
+2. 对每个索引，遍历每行的值，并将其与表中的值进行比较。
+
+如果使用 `ADMIN CHECK INDEX` 语句，它只会校验指定的索引。
 
 ## 语法图
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add more details to the `ADMIN CHECK TABLE` documentation.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.6 (TiDB 6.6 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [x] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/13375
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch

### Notes

Some notes, if desired we could add some of this to the docs, but I don't think most of this belongs in user documentation.

In `executor/executor.go` there is `CheckTableExec` which handles `ADMIN CHECK TABLE`.

Note that it sets the concurrency to the number of indexes with a maxiumum of 3:
```go
        concurrency := mathutil.Min(3, len(e.srcs))
```

If there are no indexes it doesn't do anything.

There is some special handeling for `MVIndex` (multi-valued index).

After comparing the number of entries in the index and table it starts to compare the data with the `compareData`
method of `tableWorker` in `executor/distsql.go`.

There is a chunking mechanism (chunks of 1000 records?) that is used.

Can `tidb_index_lookup_join_concurrency` be used to speedup `ADMIN CHECK TABLE`?

Any special notes for dealing with large tables?

Running multiple `ADMIN CHECK TABLE` statements at the same time is not recommended due to resource usage (e.g. memory).

Progress reporting seems to be limited to one line per index:

```
[2023/04/27 09:38:45.026 +02:00] [INFO] [admin.go:101] ["check indices count"] [table=orders] [tblCnt=345671] [index="\"idx_order\""] [idxCnt=345671]
[2023/04/27 09:38:45.229 +02:00] [INFO] [admin.go:101] ["check indices count"] [table=orders] [tblCnt=345671] [index="\"o_all_local\""] [idxCnt=345671]
```