### PR TITLE
fix PDF build failure: escape special characters

### DIFF
--- a/dumpling-overview.md
+++ b/dumpling-overview.md
@@ -358,10 +358,10 @@ SET GLOBAL tidb_gc_life_time = '10m';
 | --ca | 用于 TLS 连接的 certificate authority 文件的地址 |
 | --cert | 用于 TLS 连接的 client certificate 文件的地址 |
 | --key | 用于 TLS 连接的 client private key 文件的地址 |
-| --csv-delimiter | CSV文件中字符类型变量的定界符 | '"' |
-| --csv-separator | CSV文件中各值的分隔符，如果数据中可能有逗号，建议源文件导出时分隔符使用非常见组合字符| ','|
+| --csv-delimiter | CSV 文件中字符类型变量的定界符 | '"' |
+| --csv-separator | CSV 文件中各值的分隔符，如果数据中可能有逗号，建议源文件导出时分隔符使用非常见组合字符| ','|
 | --csv-null-value | CSV 文件空值的表示 | "\\N" |
-| --csv-line-terminator | CSV 文件中表示行尾的换行符。将数据导出为 CSV 文件时，可以通过该选项传入所需的换行符。该选项支持 "\r\n" 和 "\n"，默认值为 "\r\n"，和历史版本保持一致。由于 bash 中不同的引号会应用不同的转义规则，如需指定 LF 为换行符，可使用类似 `--csv-line-terminator $'\n'` 的语法。| "\r\n" |
+| --csv-line-terminator | CSV 文件中表示行尾的换行符。将数据导出为 CSV 文件时，可以通过该选项传入所需的换行符。该选项支持 "\\r\\n" 和 "\\n"，默认值为 "\\r\\n"，和历史版本保持一致。由于 bash 中不同的引号会应用不同的转义规则，如需指定 LF 为换行符，可使用类似 `--csv-line-terminator $'\n'` 的语法。| "\\r\\n" |
 | --escape-backslash | 使用反斜杠 (`\`) 来转义导出文件中的特殊字符 | true |
 | --output-filename-template | 以 [golang template](https://golang.org/pkg/text/template/#hdr-Arguments) 格式表示的数据文件名格式 <br/> 支持 `{{.DB}}`、`{{.Table}}`、`{{.Index}}` 三个参数 <br/> 分别表示数据文件的库名、表名、分块 ID | '{{.DB}}.{{.Table}}.{{.Index}}' |
 | --status-addr | Dumpling 的服务地址，包含了 Prometheus 拉取 metrics 信息及 pprof 调试的地址 | ":8281" |


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

After merging https://github.com/pingcap/docs-cn/pull/15044, pandoc fails to build the PDF due to an "Undefined control sequence" error. Log : https://ci.pingcap.net/blue/organizations/jenkins/common-check/detail/common-check/237911/pipeline/

```log
[2023-10-07T14:15:32.695Z] ! Undefined control sequence.
[2023-10-07T14:15:32.695Z] <argument> \n 
[2023-10-07T14:15:32.695Z]               
[2023-10-07T14:15:32.695Z] l.109783 ...�的换行符。该选项支持 ``\r\n
[2023-10-07T14:15:32.695Z] 
[2023-10-07T14:15:32.695Z] pandoc: Error producing PDF
script returned exit code 43
```

This PR fixes this issue by escaping special characters in the table.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.2 (TiDB 7.2 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v7.0 (TiDB 7.0 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
