### PR TITLE
v6.6 deprecates block-cache-size

### DIFF
--- a/alert-rules.md
+++ b/alert-rules.md
@@ -448,7 +448,7 @@ aliases: ['/docs-cn/dev/alert-rules/','/docs-cn/dev/reference/alert-rules/']
 
 * 处理方法：
 
-    调整 `rocksdb.defaultcf` 和 `rocksdb.writecf` 的 `block-cache-size` 的大小。
+    调整 [`storage.block-cache.capacity`](/tikv-configuration-file.md#capacity) 的大小。
 
 #### `TiKV_GC_can_not_work`
 

--- a/dynamic-config.md
+++ b/dynamic-config.md
@@ -190,7 +190,6 @@ show warnings;
 | {db-name}.bytes-per-sync | 异步同步的限速速率 |
 | {db-name}.wal-bytes-per-sync | WAL 同步的限速速率 |
 | {db-name}.writable-file-max-buffer-size | WritableFileWrite 所使用的最大的 buffer 大小 |
-| {db-name}.{cf-name}.block-cache-size | block cache size 大小 |
 | {db-name}.{cf-name}.write-buffer-size | memtable 大小 |
 | {db-name}.{cf-name}.max-write-buffer-number | 最大 memtable 个数 |
 | {db-name}.{cf-name}.max-bytes-for-level-base | base level (L1) 最大字节数 |

--- a/faq/manage-cluster-faq.md
+++ b/faq/manage-cluster-faq.md
@@ -301,7 +301,7 @@ TiKV 使用了 RocksDB 的 Column Family (CF) 特性，KV 数据最终存储在�
 - write CF 存储的是数据的版本信息 (MVCC)、索引、小表相关的数据，相关的参数位于 `[rocksdb.writecf]` 项中。
 - lock CF 存储的是锁信息，系统使用默认参数。
 - Raft RocksDB 实例存储 Raft log。default CF 主要存储的是 Raft log，与其对应的参数位于 `[raftdb.defaultcf]` 项中。
-- 所有 CF 共享一个 Block-cache，用于缓存数据块，加速 RocksDB 的读取速度。Block-cache 的大小通过参数 `block-cache-size` 控制，`block-cache-size` 越大，能够缓存的热点数据越多，对读取操作越有利，同时占用的系统内存也会越多。
+- 所有 CF 共享一个 block cache，用于缓存数据块，加速 RocksDB 的读取速度。block cache 的大小通过参数 [`storage.block-cache.capacity`](/tikv-configuration-file.md#capacity) 控制，`storage.block-cache.capacity` 越大，能够缓存的热点数据越多，对读取操作越有利，同时占用的系统内存也会越多。
 - 每个 CF 有各自的 Write-buffer，大小通过 `write-buffer-size` 控制。
 
 ### TiKV channel full 是什么原因？
@@ -374,7 +374,7 @@ TiKV 支持单独进行接口调用，理论上也可以起个实例做为 Cache
 
 ### 为什么 TiKV 容易出现 OOM？
 
-TiKV 的内存占用主要来自于 RocksDB 的 block-cache，默认为系统总内存的 40%。当 TiKV 容易出现 OOM 时，检查 `block-cache-size` 配置是否过高。还需要注意，当单机部署了多个 TiKV 实例时，需要显式地配置该参数，以防止多个实例占用过多系统内存导致 OOM。
+TiKV 的内存占用主要来自于 RocksDB 的 block-cache，默认为系统总内存的 40%。当 TiKV 容易出现 OOM 时，检查 [`storage.block-cache.capacity`](/tikv-configuration-file.md#capacity) 配置是否过高。还需要注意，当单机部署了多个 TiKV 实例时，需要显式地配置该参数，以防止多个实例占用过多系统内存导致 OOM。
 
 ### TiDB 数据和 RawKV 数据可存储于同一个 TiKV 集群里吗？
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -1341,7 +1341,7 @@ rocksdb defaultcf、rocksdb writecf 和 rocksdb lockcf 相关的配置项。
 
 > **警告：**
 >
-> 从 v6.6.0 起，该配置项被废弃。
+> 从 v6.6.0 起，该配置项被废弃，你可以使用 [storage.block-cache.capacity](#capacity) 配置共享 block cache 的大小。
 
 + 一个 RocksDB block 的默认缓存大小。
 + `defaultcf` 默认值：机器总内存 * 25%

--- a/tikv-control.md
+++ b/tikv-control.md
@@ -453,6 +453,8 @@ tikv-ctl --host ip:port modify-tikv-config -n storage.block-cache.capacity -v 10
 success
 ```
 
+<!--TODO: update the description and command-->
+
 当禁用 `shared block cache` 时，为 `write` CF 设置 `block cache size`：
 
 ```shell

--- a/troubleshoot-tidb-cluster.md
+++ b/troubleshoot-tidb-cluster.md
@@ -103,7 +103,7 @@ tidb-server 无法启动的常见情况包括：
 
 + 检查 dmesg 或者 syslog 里面是否有 OOM 信息
 
-    如果有 OOM 信息并且杀掉的进程为 TiKV，请减少 TiKV 的 RocksDB 的各个 CF 的 `block-cache-size` 值。
+    如果有 OOM 信息并且杀掉的进程为 TiKV，请减少 TiKV 的 RocksDB 的 [`storage.block-cache.capacity`](/tikv-configuration-file.md#capacity) 值。
 
 + 检查 TiKV 日志是否有 panic 的 log
 

--- a/tune-tikv-memory-performance.md
+++ b/tune-tikv-memory-performance.md
@@ -77,11 +77,6 @@ log-level = "info"
 ## `shared block cache` 的大小。正常情况下应设置为系统全部内存的 30%-50%。
 ## 如果未设置该参数，则由以下字段或其默认值的总和决定。
 ##
-##   * rocksdb.defaultcf.block-cache-size 或系统全部内存的 25%
-##   * rocksdb.writecf.block-cache-size 或系统全部内存的 15%
-##   * rocksdb.lockcf.block-cache-size 或系统全部内存的 2%
-##   * raftdb.defaultcf.block-cache-size 或系统全部内存的 2%
-##
 ## 要在单个物理机上部署多个 TiKV 节点，需要显式配置该参数。
 ## 否则，TiKV 中可能会出现 OOM 错误。
 # capacity = "1GB"


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB v6.6 deprecates `block-cache-size`. This PR updates `block-cache-size` in some docs to `storage.block-cache.capacity`.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v7.5 (TiDB 7.5 versions)
- [x] v7.4 (TiDB 7.4 versions)
- [x] v7.3 (TiDB 7.3 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
