### PR TITLE
tiup, tiproxy: add version flags to tiup cluster upgrade

### DIFF
--- a/tiproxy/tiproxy-overview.md
+++ b/tiproxy/tiproxy-overview.md
@@ -55,7 +55,7 @@ TiProxy 不适用于以下场景：
 
 ## 安装和使用
 
-本节介绍使用 TiUP 部署和变更 TiProxy 的步骤。使用 TiDB Operator 部署的方式请参阅 [TiDB Operator](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable) 文档。
+本节介绍使用 TiUP 部署和变更 TiProxy 的步骤。使用 TiDB Operator 部署的方式请参阅 [TiDB Operator](https://docs.pingcap.com/zh/tidb-in-kubernetes/stable/deploy-tiproxy) 文档。
 
 ### 部署 TiProxy
 
@@ -126,7 +126,7 @@ TiProxy 不适用于以下场景：
 
 部署 TiProxy 时建议指定 TiProxy 的版本，使升级 TiDB 集群时不会升级 TiProxy。
 
-如果确实要升级 TiProxy 的版本，需加上 [`--tiproxy-version`](/tiup/tiup-component-cluster-upgrade.md) 指定 TiProxy 的版本：
+如果确实要升级 TiProxy 的版本，需加上 [`--tiproxy-version`](/tiup/tiup-component-cluster-upgrade.md#--tiproxy-version) 指定 TiProxy 的版本：
 
 ```shell
 tiup cluster upgrade <cluster-name> <version> --tiproxy-version <tiproxy-version>

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -41,11 +41,77 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 - 数据类型：`BOOLEAN`
 - 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
 
+### --ignore-version-check
+
+- 在升级前，TiUP 会检查目标版本是否大于当前版本。如果想要跳过该项检查，可以使用该选项。
+- 数据类型：`BOOLEAN`
+- 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
+
 ### --offline
 
 - 声明当前集群处于停止状态。指定该选项时，TiUP Cluster 仅原地替换集群组件的二进制文件，不执行迁移 Leader 以及重启服务等操作。
 - 数据类型：`BOOLEAN`
 - 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
+
+### --pd-version
+
+- 指定 PD 的版本。指定后，PD 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，PD 的版本与集群版本保持一致。
+
+### --tikv-version
+
+- 指定 TiKV 的版本。指定后，TiKV 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiKV 的版本与集群版本保持一致。
+
+### --tikv-cdc-version
+
+- 指定 TiKV CDC 的版本。指定后，TiKV CDC 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiKV CDC 的版本与集群版本保持一致。
+
+### --tiflash-version
+
+- 指定 TiFlash 的版本。指定后，TiFlash 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiFlash 的版本与集群版本保持一致。
+
+### --cdc-version
+
+- 指定 TiCDC 的版本。指定后，TiCDC 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiCDC 的版本与集群版本保持一致。
+
+### --tiproxy-version
+
+- 指定 TiProxy 的版本。指定后，TiProxy 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiProxy 的版本与集群版本保持一致。
+
+### --tidb-dashboard-version
+
+- 指定 TiDB Dashboard 的版本。指定后，TiDB Dashboard 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，TiDB Dashboard 的版本与集群版本保持一致。
+
+### --alertmanager-version
+
+- 指定 alert manager 的版本。指定后，alert manager 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，alert manager 的版本与集群版本保持一致。
+
+### --blackbox-exporter-version
+
+- 指定 Blackbox Exporter 的版本。指定后，Blackbox Exporter 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，Blackbox Exporter 的版本与集群版本保持一致。
+
+### --node-exporter-version
+
+- 指定 Node Exporter 的版本。指定后，Node Exporter 的版本将不再与集群版本保持一致。
+- 数据类型：`STRINGS`
+- 不指定该选项时，Node Exporter 的版本与集群版本保持一致。
 
 ### -h, --help
 

--- a/tiup/tiup-component-cluster-upgrade.md
+++ b/tiup/tiup-component-cluster-upgrade.md
@@ -43,7 +43,7 @@ tiup cluster upgrade <cluster-name> <version> [flags]
 
 ### --ignore-version-check
 
-- 在升级前，TiUP 会检查目标版本是否大于当前版本。如果想要跳过该项检查，可以使用该选项。
+- 在升级前，TiUP 会检查目标版本是否大于等于当前版本。如果想要跳过该项检查，可以使用该选项。
 - 数据类型：`BOOLEAN`
 - 该选项默认关闭，默认值为 `false`。在命令中添加该选项，并传入 `true` 值或不传值，均可开启此功能。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

- TiUP Cluster supports specifying versions of specific components:

```
Flags:
      --alertmanager-version string        Fix the version of alertmanager and no longer follows the cluster version.
      --blackbox-exporter-version string   Fix the version of blackbox-exporter and no longer follows the cluster version.
      --cdc-version string                 Fix the version of cdc and no longer follows the cluster version.
      --force                              Force upgrade without transferring PD leader
  -h, --help                               help for upgrade
      --ignore-config-check                Ignore the config check result
      --ignore-version-check               Ignore checking if target version is bigger than current version
      --node-exporter-version string       Fix the version of node-exporter and no longer follows the cluster version.
      --offline                            Upgrade a stopped cluster
      --pd-version string                  Fix the version of pv and no longer follows the cluster version.
      --post-upgrade-script string         (EXPERIMENTAL) Custom script to be executed on each server after the server is upgraded
      --pre-upgrade-script string          (EXPERIMENTAL) Custom script to be executed on each server before the server is upgraded
      --tidb-dashboard-version string      Fix the version of tidb-dashboard and no longer follows the cluster version.
      --tiflash-version string             Fix the version of tiflash and no longer follows the cluster version.
      --tikv-cdc-version string            Fix the version of tikv-cdc and no longer follows the cluster version.
      --tikv-version string                Fix the version of tikv and no longer follows the cluster version.
      --tiproxy-version string             Fix the version of tiproxy and no longer follows the cluster version.
      --transfer-timeout uint              Timeout in seconds when transferring PD and TiKV store leaders, also for TiCDC drain one capture (default 600)
```

- Update the links in TiProxy overview doc

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.3 (TiDB 7.3 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
