### PR TITLE
include description about extending timeout of TiUP when force-init-stats is ON

### DIFF
--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -27,8 +27,8 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待时间。
 >    - 可能受影响的场景：
->      * 原集群版本低于 v6.5.6, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
->      * 原集群版本高于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
+>      * 原集群版本低于 v6.5.7, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
+>      * 原集群版本高于或等于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
 >   * 查看配置项 `performance.force-init-stats` 的值：
 >     ```
 >     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
@@ -41,6 +41,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >     ```
 >     [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
 >      ```
+>    * 如果原数据库是 v7.1.0 或更低，升级到 v7.2.0 以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，加载时间会大幅减少。这个情况下，用上述方法做的时间预估会偏长。
 >    * 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -47,7 +47,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >         [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
 >         ```
 >
->          如果原集群是 v7.1.0 或更早的版本，升级到 v7.2.0 以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，统计信息加载时间会大幅减少。这个情况下，升级前的 `init stats info time` 会比升级后加载所需的时间偏长。
+>          如果原集群是 v7.1.0 或更早的版本，升级到 v7.2.0 或以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，统计信息加载时间会大幅减少。这个情况下，升级前的 `init stats info time` 会比升级后加载所需的时间偏长。
 >     - 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响，可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -27,7 +27,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待超时。
 >    - 可能受影响的场景：
->      * 原集群版本低于 v6.5.7, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
+>      * 原集群版本低于 v6.5.7, v7.1.0 ( 尚未支持 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
 >      * 原集群版本高于或等于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
 >   * 查看配置项 `performance.force-init-stats` 的值：
 >     ```

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -25,23 +25,23 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 如果原集群是 3.0 或 3.1 或更早的版本，不支持直接升级到 v7.6.0 及后续修订版本。你需要先从早期版本升级到 4.0 后，再从 4.0 升级到 v7.6.0 及后续修订版本。
 > - 如果原集群是 6.2 之前的版本，升级到 6.2 及以上版本时，部分场景会遇到升级卡住的情况，你可以参考[如何解决升级卡住的问题](#42-升级到-v620-及以上版本时如何解决升级卡住的问题)。
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
-> - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。建议为 TiUP 设置更长的等待时间。
->   * 可能影响的场景
+> - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待时间。
+>    - 可能受影响的场景：
 >      * 原集群版本低于 v6.5.6, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
 >      * 原集群版本高于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
->   * 查看配置项 `performance.force-init-stats` 的值。
+>   * 查看配置项 `performance.force-init-stats` 的值：
 >     ```
 >     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
 >     ```
->   * 通过增加命令行选项 [`--wait-timeout`](/tiup/tiup-component-cluster#wait-timeoutuint默认-120) 延长超时等待。如下将等待时间设置成 20 分钟
+>   * 通过增加命令行选项 [`--wait-timeout`](/tiup/tiup-component-cluster.md#--wait-timeoutuint默认-120) 延长 TiUP 超时等待。如下命令可将超时等待设置成 1200 秒（即 20 分钟）。
 >     ```shell
 >     tiup update cluster --wait-timeout 1200 [other options]
 >     ```
->     通常情况下，20分钟超时能满足绝大部分场景的等待。如果想要做更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的加载时间作为参考。 例如：
+>     通常情况下，20 分钟超时等待能满足绝大部分场景的需求。如果需要更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的加载时间作为参考。 例如：
 >     ```
 >     [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
 >      ```
->    * 如果想要加快 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
+>    * 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
 
 ## 1. 升级兼容性说明

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -27,7 +27,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待超时。
 >     - 可能受影响的场景：
->         - 原集群版本低于 v6.5.7、v7.1.0 ( 尚未支持 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
+>         - 原集群版本低于 v6.5.7、v7.1.0（尚未支持 `performance.force-init-stats`），目标版本为 v7.2.0 及更高。
 >         - 原集群版本高于或等于 v6.5.7、v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
 >     - 查看配置项 `performance.force-init-stats` 的值：
 >

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -25,7 +25,10 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 如果原集群是 3.0 或 3.1 或更早的版本，不支持直接升级到 v7.6.0 及后续修订版本。你需要先从早期版本升级到 4.0 后，再从 4.0 升级到 v7.6.0 及后续修订版本。
 > - 如果原集群是 6.2 之前的版本，升级到 6.2 及以上版本时，部分场景会遇到升级卡住的情况，你可以参考[如何解决升级卡住的问题](#42-升级到-v620-及以上版本时如何解决升级卡住的问题)。
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
-> - 如果原集群为 v7.1.0 及更高版本，配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。建议为 TiUP 设置更长的等待时间
+> - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。建议为 TiUP 设置更长的等待时间。
+>   * 可能影响的场景
+>      * 原集群版本低于 v6.5.6, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
+>      * 原集群版本高于 v6.5.7, v7.1.0 ，且 配置项 `performance.force-init-stats` 设置为 `ON`。 
 >   * 查看配置项 `force-init-stats` 的值。
 >     ```
 >     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -41,7 +41,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >         tiup update cluster --wait-timeout 1200 [other options]
 >         ```
 >
->         通常情况下，20 分钟超时等待能满足绝大部分场景的需求。如果需要更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的统计信息加载时间作为参考。 例如：
+>         通常情况下，20 分钟超时等待能满足绝大部分场景的需求。如果需要更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的统计信息加载时间作为参考。例如：
 >
 >         ```
 >         [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -26,23 +26,29 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 如果原集群是 6.2 之前的版本，升级到 6.2 及以上版本时，部分场景会遇到升级卡住的情况，你可以参考[如何解决升级卡住的问题](#42-升级到-v620-及以上版本时如何解决升级卡住的问题)。
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待超时。
->    - 可能受影响的场景：
->      * 原集群版本低于 v6.5.7, v7.1.0 ( 尚未支持 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
->      * 原集群版本高于或等于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
->   * 查看配置项 `performance.force-init-stats` 的值：
->     ```
->     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
->     ```
->   * 通过增加命令行选项 [`--wait-timeout`](/tiup/tiup-component-cluster.md#--wait-timeoutuint默认-120) 延长 TiUP 超时等待。如下命令可将超时等待设置成 1200 秒（即 20 分钟）。
->     ```shell
->     tiup update cluster --wait-timeout 1200 [other options]
->     ```
->     通常情况下，20 分钟超时等待能满足绝大部分场景的需求。如果需要更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的加载时间作为参考。 例如：
->     ```
->     [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
->      ```
->    * 如果原数据库是 v7.1.0 或更低，升级到 v7.2.0 以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，加载时间会大幅减少。这个情况下，用上述方法做的时间预估会偏长。
->    * 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
+>     - 可能受影响的场景：
+>         - 原集群版本低于 v6.5.7、v7.1.0 ( 尚未支持 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
+>         - 原集群版本高于或等于 v6.5.7、v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
+>     - 查看配置项 `performance.force-init-stats` 的值：
+>
+>         ```
+>         SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
+>         ```
+>
+>     - 通过增加命令行选项 [`--wait-timeout`](/tiup/tiup-component-cluster.md#--wait-timeoutuint默认-120) 可以延长 TiUP 超时等待。如下命令可将超时等待设置为 1200 秒（即 20 分钟）。
+>
+>         ```shell
+>         tiup update cluster --wait-timeout 1200 [other options]
+>         ```
+>
+>         通常情况下，20 分钟超时等待能满足绝大部分场景的需求。如果需要更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的统计信息加载时间作为参考。 例如：
+>
+>         ```
+>         [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
+>         ```
+>
+>          如果原集群是 v7.1.0 或更早的版本，升级到 v7.2.0 以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，统计信息加载时间会大幅减少。这个情况下，升级前的 `init stats info time` 会比升级后加载所需的时间偏长。
+>     - 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响，可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
 
 ## 1. 升级兼容性说明

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -25,7 +25,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 如果原集群是 3.0 或 3.1 或更早的版本，不支持直接升级到 v7.6.0 及后续修订版本。你需要先从早期版本升级到 4.0 后，再从 4.0 升级到 v7.6.0 及后续修订版本。
 > - 如果原集群是 6.2 之前的版本，升级到 6.2 及以上版本时，部分场景会遇到升级卡住的情况，你可以参考[如何解决升级卡住的问题](#42-升级到-v620-及以上版本时如何解决升级卡住的问题)。
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
-> - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待时间。
+> - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待超时。
 >    - 可能受影响的场景：
 >      * 原集群版本低于 v6.5.7, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
 >      * 原集群版本高于或等于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -28,7 +28,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。为避免这种情况，建议为 TiUP 设置更长的等待超时。
 >     - 可能受影响的场景：
 >         - 原集群版本低于 v6.5.7、v7.1.0（尚未支持 `performance.force-init-stats`），目标版本为 v7.2.0 及更高。
->         - 原集群版本高于或等于 v6.5.7、v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
+>         - 原集群版本高于或等于 v6.5.7、v7.1.0，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
 >     - 查看配置项 `performance.force-init-stats` 的值：
 >
 >         ```

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -28,8 +28,8 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。建议为 TiUP 设置更长的等待时间。
 >   * 可能影响的场景
 >      * 原集群版本低于 v6.5.6, v7.1.0 ( 没有配置项 `performance.force-init-stats` )，目标版本为 v7.2.0 及更高。
->      * 原集群版本高于 v6.5.7, v7.1.0 ，且 配置项 `performance.force-init-stats` 设置为 `ON`。 
->   * 查看配置项 `force-init-stats` 的值。
+>      * 原集群版本高于 v6.5.7, v7.1.0 ，且配置项 `performance.force-init-stats` 被设置为 `ON`。 
+>   * 查看配置项 `performance.force-init-stats` 的值。
 >     ```
 >     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
 >     ```
@@ -41,7 +41,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >     ```
 >     [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
 >      ```
->    * 如果想要加快 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
+>    * 如果想要加快 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
 
 ## 1. 升级兼容性说明

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -50,7 +50,6 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >          如果原集群是 v7.1.0 或更早的版本，升级到 v7.2.0 或以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，统计信息加载时间会大幅减少。这个情况下，升级前的 `init stats info time` 会比升级后加载所需的时间偏长。
 >     - 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响，可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
 
-
 ## 1. 升级兼容性说明
 
 - TiDB 目前暂不支持版本降级或升级后回退。

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -48,7 +48,7 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 >         ```
 >
 >          如果原集群是 v7.1.0 或更早的版本，升级到 v7.2.0 或以上版本时，由于 [`performance.lite-init-stats`](/tidb-configuration-file.md#lite-init-stats-从-v710-版本开始引入) 的引入，统计信息加载时间会大幅减少。这个情况下，升级前的 `init stats info time` 会比升级后加载所需的时间偏长。
->     - 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响，可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
+>     - 如果想要缩短 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响，可以在升级前[用 TiUP 修改目标实例的配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。升级完成后可酌情改回。
 
 ## 1. 升级兼容性说明
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -25,6 +25,21 @@ aliases: ['/docs-cn/dev/upgrade-tidb-using-tiup/','/docs-cn/dev/how-to/upgrade/u
 > - 如果原集群是 3.0 或 3.1 或更早的版本，不支持直接升级到 v7.6.0 及后续修订版本。你需要先从早期版本升级到 4.0 后，再从 4.0 升级到 v7.6.0 及后续修订版本。
 > - 如果原集群是 6.2 之前的版本，升级到 6.2 及以上版本时，部分场景会遇到升级卡住的情况，你可以参考[如何解决升级卡住的问题](#42-升级到-v620-及以上版本时如何解决升级卡住的问题)。
 > - 配置参数 [`server-version`](/tidb-configuration-file.md#server-version) 的值会被 TiDB 节点用于验证当前 TiDB 的版本。因此在进行 TiDB 集群升级前，请将 `server-version` 的值设置为空或者当前 TiDB 真实的版本值，避免出现非预期行为。
+> - 如果原集群为 v7.1.0 及更高版本，配置项 [`performance.force-init-stats`](/tidb-configuration-file.md#force-init-stats-从-v657-和-v710-版本开始引入) 设置为 `ON` 会延长 TiDB 的启动时间，这可能会造成启动超时，升级失败。建议为 TiUP 设置更长的等待时间
+>   * 查看配置项 `force-init-stats` 的值。
+>     ```
+>     SHOW CONFIG WHERE type = 'tidb' AND name = 'performance.force-init-stats';
+>     ```
+>   * 通过增加命令行选项 [`--wait-timeout`](/tiup/tiup-component-cluster#wait-timeoutuint默认-120) 延长超时等待。如下将等待时间设置成 20 分钟
+>     ```shell
+>     tiup update cluster --wait-timeout 1200 [other options]
+>     ```
+>     通常情况下，20分钟超时能满足绝大部分场景的等待。如果想要做更准确的预估，可以在 TiDB 日志中搜索 `init stats info time` 关键字，获取上次启动的加载时间作为参考。 例如：
+>     ```
+>     [domain.go:2271] ["init stats info time"] [lite=true] ["take time"=2.151333ms]
+>      ```
+>    * 如果想要加快 TiDB 滚动升级的时间，并且在升级过程中能够承受初始统计信息缺失带来的潜在性能影响。可以在升级前[用 TiUP 修改配置](/maintain-tidb-using-tiup.md#修改配置参数)，将 `performance.force-init-stats` 设置为 `OFF`。 升级完成后可酌情改回。
+
 
 ## 1. 升级兼容性说明
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->


### What is changed, added or deleted? (Required)

When `force-init-stats` is `ON`, it could reach the timeout of TiDB rolling update.  We includes additional description, list the necessary steps to avoid such problem. 

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [] v8.0 (TiDB 8.0 versions)
- [] v7.6 (TiDB 7.6 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [x] v7.1 (TiDB 7.1 versions)
- [x] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
