### PR TITLE
tidb: "PD server timeout" error message as lowercase

### DIFF
--- a/error-codes.md
+++ b/error-codes.md
@@ -451,13 +451,13 @@ TiDB 兼容 MySQL 的错误码，在大多数情况下，返回和 MySQL 一样�
 
 * Error Number: 9001
 
-    完整的报错信息为 `ERROR 9001 (HY000) : PD Server Timeout`。
+    完整的报错信息为 `ERROR 9001 (HY000) : PD server timeout`。
 
     请求 PD 超时，请检查 PD Server 状态/监控/日志以及 TiDB Server 与 PD Server 之间的网络。
 
 * Error Number: 9002
 
-    完整的报错信息为 `ERROR 9002 (HY000) : TiKV Server Timeout`。
+    完整的报错信息为 `ERROR 9002 (HY000) : TiKV server timeout`。
 
     请求 TiKV 超时，请检查 TiKV Server 状态/监控/日志以及 TiDB Server 与 TiKV Server 之间的网络。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

According to these TiDB server error messages, "PD server timeout" should be the correct error message.
S and T are both lowercase.

https://github.com/pingcap/tidb/blob/60aa838790e36e33b4105d22e191dfa827fe3663/errors.toml#L3101
https://github.com/pingcap/tidb/blob/60aa838790e36e33b4105d22e191dfa827fe3663/pkg/errno/errname.go#L1151

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [ ] v8.0 (TiDB 8.0 versions)
- [ ] v7.6 (TiDB 7.6 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.4 (TiDB 7.4 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)
- [ ] v5.2 (TiDB 5.2 versions)
- [ ] v5.1 (TiDB 5.1 versions)
- [ ] v5.0 (TiDB 5.0 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:https://github.com/pingcap/docs/pull/16661
- Other reference link(s): 

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch
