### PR TITLE
TiDB supports `MID(str, pos[, len])`

### DIFF
--- a/functions-and-operators/string-functions.md
+++ b/functions-and-operators/string-functions.md
@@ -1425,15 +1425,15 @@ SELECT MAKE_SET(b'111','foo','bar','baz');
 
 ### [`MID()`](https://dev.mysql.com/doc/refman/8.0/en/string-functions.html#function_mid)
 
-`MID(str,pos,len)` 函数返回从指定的 `pos` 位置开始的长度为 `len` 的子字符串。
+`MID(str, pos[, len])` 函数返回从指定的 `pos` 位置开始的长度为 `len` 的子字符串。
+
+从 v8.4.0 开始，TiDB 支持该函数的两参数版本，即 `MID(str, pos)`。如果未指定 `len`，则返回从指定的 `pos` 位置到字符串末尾的所有字符。
 
 如果任一参数为 `NULL`，该函数将返回 `NULL`。
 
-TiDB 不支持该函数的两参数版本。更多信息，请参见 [#52420](https://github.com/pingcap/tidb/issues/52420)。
-
 示例：
 
-在以下示例中，`MID()` 返回给定的字符串中从第二个字符 (`b`) 开始的长度为 `3` 个字符的的子字符串。
+在以下示例中，`MID()` 返回给定的字符串中从第二个字符 (`b`) 开始的长度为 `3` 个字符的子字符串。
 
 ```sql
 SELECT MID('abcdef',2,3);
@@ -1444,6 +1444,21 @@ SELECT MID('abcdef',2,3);
 | MID('abcdef',2,3) |
 +-------------------+
 | bcd               |
++-------------------+
+1 row in set (0.00 sec)
+```
+
+在以下示例中，`MID()` 返回给定的字符串中从第二个字符 (`b`) 开始到字符串末尾的子字符串。
+
+```sql
+SELECT MID('abcdef',2);
+```
+
+```
++-------------------+
+| MID('abcdef',2)   |
++-------------------+
+| bcdef             |
 +-------------------+
 1 row in set (0.00 sec)
 ```


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

TiDB v8.4.0 supports `MID(str, pos[, len])`
### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/18669
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
