### PR TITLE
chore: remove v5.3/v8.2 from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,14 +23,12 @@ For details, see [tips for choosing the affected versions (in Chinese)](https://
 - [ ] v8.5 (TiDB 8.5 versions)
 - [ ] v8.4 (TiDB 8.4 versions)
 - [ ] v8.3 (TiDB 8.3 versions)
-- [ ] v8.2 (TiDB 8.2 versions)
 - [ ] v8.1 (TiDB 8.1 versions)
 - [ ] v7.5 (TiDB 7.5 versions)
 - [ ] v7.1 (TiDB 7.1 versions)
 - [ ] v6.5 (TiDB 6.5 versions)
 - [ ] v6.1 (TiDB 6.1 versions)
 - [ ] v5.4 (TiDB 5.4 versions)
-- [ ] v5.3 (TiDB 5.3 versions)
 
 ### What is the related PR or file link(s)?
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 | [`release-8.5`](https://github.com/pingcap/docs-cn/tree/release-8.5) | 8.5 长期支持版 (LTS) |
 | [`release-8.4`](https://github.com/pingcap/docs-cn/tree/release-8.4) | 8.4 开发里程碑版 (DMR) |
 | [`release-8.3`](https://github.com/pingcap/docs-cn/tree/release-8.3) | 8.3 开发里程碑版 (DMR) |
-| [`release-8.2`](https://github.com/pingcap/docs-cn/tree/release-8.2) | 8.2 开发里程碑版 (DMR) |
+| [`release-8.2`](https://github.com/pingcap/docs-cn/tree/release-8.2) | 8.2 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新） |
 | [`release-8.1`](https://github.com/pingcap/docs-cn/tree/release-8.1) | 8.1 长期支持版 (LTS) |
 | [`release-8.0`](https://github.com/pingcap/docs-cn/tree/release-8.0) | 8.0 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新）|
 | [`release-7.6`](https://github.com/pingcap/docs-cn/tree/release-7.6) | 7.6 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新）|
@@ -36,7 +36,7 @@
 | [`release-6.1`](https://github.com/pingcap/docs-cn/tree/release-6.1) | 6.1 长期支持版 (LTS) |
 | [`release-6.0`](https://github.com/pingcap/docs-cn/tree/release-6.0) | 6.0 开发里程碑版 (DMR)（该版本文档已归档，不再提供任何更新） |
 | [`release-5.4`](https://github.com/pingcap/docs-cn/tree/release-5.4) | 5.4 稳定版 |
-| [`release-5.3`](https://github.com/pingcap/docs-cn/tree/release-5.3) | 5.3 稳定版 |
+| [`release-5.3`](https://github.com/pingcap/docs-cn/tree/release-5.3) | 5.3 稳定版 （该版本文档已归档，不再提供任何更新） |
 | [`release-5.2`](https://github.com/pingcap/docs-cn/tree/release-5.2) | 5.2 稳定版 （该版本文档已归档，不再提供任何更新）|
 | [`release-5.1`](https://github.com/pingcap/docs-cn/tree/release-5.1) | 5.1 稳定版 （该版本文档已归档，不再提供任何更新）|
 | [`release-5.0`](https://github.com/pingcap/docs-cn/tree/release-5.0) | 5.0 稳定版（该版本文档已归档，不再提供任何更新） |

--- a/resources/cdnfresh.txt
+++ b/resources/cdnfresh.txt
@@ -6,8 +6,6 @@ https://download.pingcap.org/tidb-v8.4-zh-manual.pdf
 https://download.pingcap.org/tidb-v8.4-en-manual.pdf
 https://download.pingcap.org/tidb-v8.3-zh-manual.pdf
 https://download.pingcap.org/tidb-v8.3-en-manual.pdf
-https://download.pingcap.org/tidb-v8.2-zh-manual.pdf
-https://download.pingcap.org/tidb-v8.2-en-manual.pdf
 https://download.pingcap.org/tidb-v8.1-zh-manual.pdf
 https://download.pingcap.org/tidb-v8.1-en-manual.pdf
 https://download.pingcap.org/tidb-v8.0-zh-manual.pdf
@@ -24,8 +22,6 @@ https://download.pingcap.org/tidb-v6.1-zh-manual.pdf
 https://download.pingcap.org/tidb-v6.1-en-manual.pdf
 https://download.pingcap.org/tidb-v5.4-zh-manual.pdf
 https://download.pingcap.org/tidb-v5.4-en-manual.pdf
-https://download.pingcap.org/tidb-v5.3-zh-manual.pdf
-https://download.pingcap.org/tidb-v5.3-en-manual.pdf
 https://download.pingcap.org/tidb-v5.2-zh-manual.pdf
 https://download.pingcap.org/tidb-v5.2-en-manual.pdf
 https://download.pingcap.org/tidb-v5.1-zh-manual.pdf
@@ -40,6 +36,4 @@ https://download.pingcap.org/tidb-in-kubernetes-v1.4-zh-manual.pdf
 https://download.pingcap.org/tidb-in-kubernetes-v1.4-en-manual.pdf
 https://download.pingcap.org/tidb-in-kubernetes-v1.3-zh-manual.pdf
 https://download.pingcap.org/tidb-in-kubernetes-v1.3-en-manual.pdf
-https://download.pingcap.org/tidb-in-kubernetes-v1.2-zh-manual.pdf
-https://download.pingcap.org/tidb-in-kubernetes-v1.2-en-manual.pdf
 https://download.pingcap.org/tidbcloud-en-manual.pdf


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove v5.3/v8.2 from the PR template because v5.3/v8.2 docs have been archived at [docs-archive.pingcap.com/zh/tidb](https://docs-archive.pingcap.com/zh/tidb) and will no longer receive new updates.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
