### PR TITLE
tiproxy: add multi-vip support to v1.3.1

### DIFF
--- a/tiproxy/tiproxy-configuration.md
+++ b/tiproxy/tiproxy-configuration.md
@@ -137,7 +137,7 @@ TiProxy 的高可用配置。
 
 + 默认值：`""`
 + 支持热加载：否
-+ 指定虚拟 IP 地址，使用 CIDR 格式表示，例如 `"10.0.1.10/24"`。当集群中部署了多台 TiProxy 时，只有一台 TiProxy 会绑定虚拟 IP。当该 TiProxy 下线时，另外一台 TiProxy 会自动绑定该 IP，确保客户端始终能通过虚拟 IP 连接到可用的 TiProxy。
++ 指定虚拟 IP 地址，使用 CIDR 格式表示，例如 `"10.0.1.10/24"`。当集群中有多台 TiProxy 配置同一虚拟 IP 时，只有一台 TiProxy 会绑定该虚拟 IP。当该 TiProxy 下线时，另外一台 TiProxy 会自动绑定该 IP，确保客户端始终能通过虚拟 IP 连接到可用的 TiProxy。
 
 配置示例：
 
@@ -148,11 +148,13 @@ server_configs:
     ha.interface: "eth0"
 ```
 
+从 v1.3.1 开始支持配置多个虚拟 IP。当需要隔离计算层资源时，可以配置多个虚拟 IP，并结合使用[基于标签的负载均衡](/tiproxy/tiproxy-load-balance.md#基于标签的负载均衡)。示例可参见[基于标签的负载均衡](/tiproxy/tiproxy-load-balance.md#基于标签的负载均衡)。
+
 > **注意：**
 >
 > - 虚拟 IP 仅支持 Linux 操作系统。
 > - 运行 TiProxy 的 Linux 用户必须具有绑定 IP 地址的权限。
-> - 虚拟 IP 和所有 TiProxy 实例的 IP 必须处于同一个 CIDR 范围内。
+> - TiProxy 实例的真实 IP 和虚拟 IP 必须处于同一个 CIDR 范围内。
 
 #### `interface`
 

--- a/tiproxy/tiproxy-load-balance.md
+++ b/tiproxy/tiproxy-load-balance.md
@@ -38,18 +38,19 @@ TiProxy 定时通过 SQL 端口和状态端口检查 TiDB 是否已下线或正�
 例如，若应用包含交易和 BI 两类业务，为了避免相互影响，可以按照如下方式配置集群：
 
 1. 在 TiProxy 上配置 [`balance.label-name`](/tiproxy/tiproxy-configuration.md#label-name) 为 `"app"`，表示将按照标签名 `"app"` 匹配 TiDB server，并将连接路由到相同标签值的 TiDB server 上。
-2. 配置 2 台 TiProxy 实例，分别为配置项 [`labels`](/tiproxy/tiproxy-configuration.md#labels) 加上 `"app"="Order"` 和 `"app"="BI"`。
-3. 将 TiDB 实例分为 2 组，分别为配置项 [`labels`](/tidb-configuration-file.md#labels) 加上 `"app"="Order"` 和 `"app"="BI"`。 
-4. 如果需要同时隔离存储层的资源，可配置 [Placement Rules](/configure-placement-rules.md) 或[资源管控 (Resource Control)](/tidb-resource-control-ru-groups.md)。
-5. 交易和 BI 业务的客户端分别连接到 2 台 TiProxy 的地址。
+2. 配置至少 2 台 TiProxy 实例，用于交易业务的 TiProxy 实例配置 [`labels`](/tiproxy/tiproxy-configuration.md#labels) 为 `{"app"="Order"}`；用于 BI 业务的实例配置 [`labels`](/tiproxy/tiproxy-configuration.md#labels) 为 `{"app"="BI"}`。
+3. 如果同时需要 TiProxy 的高可用，配置至少 4 台 TiProxy 实例，不同业务的实例配置不同的虚拟 IP。例如用于交易业务的 2 台 TiProxy 实例配置虚拟 IP `10.0.1.10/24`，用于 BI 业务的 2 台 TiProxy 实例配置虚拟 IP `10.0.1.20/24`。TiProxy 从 v1.3.1 开始支持配置多个虚拟 IP，请确保升级到 v1.3.1 及以上版本。
+4. 将 TiDB 实例分为 2 组，分别为配置项 [`labels`](/tidb-configuration-file.md#labels) 加上 `"app"="Order"` 和 `"app"="BI"`。 
+5. 如果需要同时隔离存储层的资源，可配置 [Placement Rules](/configure-placement-rules.md) 或[资源管控](/tidb-resource-control-ru-groups.md)。
+6. 交易和 BI 业务的客户端分别连接到 2 个虚拟 IP 地址。
 
-<img src="https://docs-download.pingcap.com/media/images/docs-cn/tiproxy/tiproxy-balance-label.png" alt="基于标签的负载均衡" width="600" />
+<img src="https://docs-download.pingcap.com/media/images/docs-cn/tiproxy/tiproxy-balance-label-v2.png" alt="基于标签的负载均衡" width="600" />
 
 上述拓扑图的配置示例如下：
 
 ```yaml
 component_versions:
-  tiproxy: "v1.1.0"
+  tiproxy: "v1.3.1"
 server_configs:
   tiproxy:
     balance.label-name: "app"
@@ -58,23 +59,37 @@ server_configs:
 tiproxy_servers:
   - host: tiproxy-host-1
     config:
-      labels: {app: "Order"}
+      labels: {"app": "Order"}
+      ha.virtual-ip: "10.0.1.10/24"
+      ha.interface: "eth0"
   - host: tiproxy-host-2
     config:
-      labels: {app: "BI"}
+      labels: {"app": "Order"}
+      ha.virtual-ip: "10.0.1.10/24"
+      ha.interface: "eth0"
+  - host: tiproxy-host-3
+    config:
+      labels: {"app": "BI"}
+      ha.virtual-ip: "10.0.1.20/24"
+      ha.interface: "eth0"
+  - host: tiproxy-host-4
+    config:
+      labels: {"app": "BI"}
+      ha.virtual-ip: "10.0.1.20/24"
+      ha.interface: "eth0"
 tidb_servers:
   - host: tidb-host-1
     config:
-      labels: {app: "Order"}
+      labels: {"app": "Order"}
   - host: tidb-host-2
     config:
-      labels: {app: "Order"}
+      labels: {"app": "Order"}
   - host: tidb-host-3
     config:
-      labels: {app: "BI"}
+      labels: {"app": "BI"}
   - host: tidb-host-4
     config:
-      labels: {app: "BI"}
+      labels: {"app": "BI"}
 tikv_servers:
   - host: tikv-host-1
   - host: tikv-host-2


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

According to the feedback from the business team, deploying one TiProxy for each group in a label-based load balance doesn't make sense. To enable label-based load balance, multiple VIP must be supported, so I backported multiple VIP into v.1.3.1.

Most words are the same as the master branch. I added the claim of v1.3.1.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
