### PR TITLE
chore: remove v8.3 and v8.4 from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,8 +21,6 @@ For details, see [tips for choosing the affected versions (in Chinese)](https://
 - [ ] master (the latest development version)
 - [ ] v9.0 (TiDB 9.0 versions)
 - [ ] v8.5 (TiDB 8.5 versions)
-- [ ] v8.4 (TiDB 8.4 versions)
-- [ ] v8.3 (TiDB 8.3 versions)
 - [ ] v8.1 (TiDB 8.1 versions)
 - [ ] v7.5 (TiDB 7.5 versions)
 - [ ] v7.1 (TiDB 7.1 versions)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@
 |:---------|:----------|
 | [`master`](https://github.com/pingcap/docs-cn/tree/master) | dev 最新开发版 |
 | [`release-8.5`](https://github.com/pingcap/docs-cn/tree/release-8.5) | 8.5 长期支持版 (LTS) |
-| [`release-8.4`](https://github.com/pingcap/docs-cn/tree/release-8.4) | 8.4 开发里程碑版 (DMR) |
-| [`release-8.3`](https://github.com/pingcap/docs-cn/tree/release-8.3) | 8.3 开发里程碑版 (DMR) |
+| [`release-8.4`](https://github.com/pingcap/docs-cn/tree/release-8.4) | 8.4 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新） |
+| [`release-8.3`](https://github.com/pingcap/docs-cn/tree/release-8.3) | 8.3 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新） |
 | [`release-8.2`](https://github.com/pingcap/docs-cn/tree/release-8.2) | 8.2 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新） |
 | [`release-8.1`](https://github.com/pingcap/docs-cn/tree/release-8.1) | 8.1 长期支持版 (LTS) |
 | [`release-8.0`](https://github.com/pingcap/docs-cn/tree/release-8.0) | 8.0 开发里程碑版 (DMR) （该版本文档已归档，不再提供任何更新）|


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Remove v8.3 and v8.4 from the PR template because these docs have been archived at [docs-archive.pingcap.com/zh/tidb](https://docs-archive.pingcap.com/zh/tidb) and will no longer receive new updates.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
