### PR TITLE
tiflash: Add warnings about LOCATION LABELS on ALTER TABLE ... SET TIFLASH REPLICA

### DIFF
--- a/tiflash/create-tiflash-replicas.md
+++ b/tiflash/create-tiflash-replicas.md
@@ -238,7 +238,7 @@ SELECT TABLE_NAME FROM information_schema.tables where TABLE_SCHEMA = "<db_name>
 
 3. 此时 PD 会根据 TiFlash 节点 `learner_config` 的 `server.labels` 以及表的副本数 `count` 进行调度，将表 `t` 的副本分别调度到不同的可用区中，保证可用性。详情请参考[通过拓扑 label 进行副本调度](/schedule-replicas-by-topology-labels.md)。可以通过下列 SQL 来验证某个表 Region 在 TiFlash 节点上的分布：
 
-    ```SQL
+    ```sql
     -- Non-partitioned table
     SELECT table_id, p.store_id, address, COUNT(p.region_id) 
     FROM


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

According to the discussion with @JmPotato , the current implementation of `LOCATION LABELS` is not correct and may acts does not meet the user want. Fixing the behavior requires manpower, and there is currently no plan or demand from users. So just add warnings about it.

For example, if the user set `LOCATION LABELS` with the similar string as placement-rule-in-SQL does: https://docs.pingcap.com/zh/tidb/stable/placement-rules-in-sql/#%E6%8C%87%E5%AE%9A%E7%94%9F%E5%AD%98%E5%81%8F%E5%A5%BD

```
alter table t set tiflash replica 2 LOCATION LABELS "[region, zone, host]"
```

then the generated placement-rule in PD is

```JSON
  {
    "group_id": "tiflash",
    ...
    "start_key": "748000000000055fff795f720000000000fa",
    "end_key": "748000000000055fff7a00000000000000f8",
    "role": "learner",
    "count": 2,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": ["tiflash"]
      }
    ],
    "location_labels": [
      "[region, zone, host]"
    ],
  }
```

but not

```JSON
  {
    "group_id": "tiflash",
    ...
    "start_key": "748000000000055fff795f720000000000fa",
    "end_key": "748000000000055fff7a00000000000000f8",
    "role": "learner",
    "count": 2,
    "label_constraints": [
      {
        "key": "engine",
        "op": "in",
        "values": ["tiflash"]
      }
    ],
    "location_labels": [
      "region",
      "zone",
      "host"
    ],
  }
```

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [x] v8.1 (TiDB 8.1 versions)
- [x] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs/pull/21692

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch
