### PR TITLE
tikv-configuration-file: update flow-control override behavior for v8.5.5

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -568,7 +568,7 @@ RocksDB 多个 CF 之间共享 block cache 的配置选项。
 
     > **注意**：
     >
-    > 当满足一定条件时，`rocksdb.(defaultcf|writecf|lockcf).level0-slowdown-writes-trigger` 的值会被该配置项覆盖。详情参考 [`rocksdb.(defaultcf|writecf|lockcf).level0-slowdown-writes-trigger`](/tikv-configuration-file.md#level0-slowdown-writes-trigger)。
+    > 当满足一定条件时，`rocksdb.(defaultcf|writecf|lockcf|raftcf).level0-slowdown-writes-trigger` 的值会被该配置项覆盖。详情参考 [`rocksdb.(defaultcf|writecf|lockcf|raftcf).level0-slowdown-writes-trigger`](/tikv-configuration-file.md#level0-slowdown-writes-trigger)。
 
 + 默认值：20
 
@@ -578,7 +578,7 @@ RocksDB 多个 CF 之间共享 block cache 的配置选项。
 
     > **注意**：
     >
-    > 当满足一定条件时，`rocksdb.(defaultcf|writecf|lockcf).soft-pending-compaction-bytes-limit` 的值会被该配置项覆盖。详情参考 [`rocksdb.(defaultcf|writecf|lockcf).soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit-1)。
+    > 当满足一定条件时，`rocksdb.(defaultcf|writecf|lockcf|raftcf).soft-pending-compaction-bytes-limit` 的值会被该配置项覆盖。详情参考 [`rocksdb.(defaultcf|writecf|lockcf|raftcf).soft-pending-compaction-bytes-limit`](/tikv-configuration-file.md#soft-pending-compaction-bytes-limit-1)。
 
 + 默认值："192GiB"
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### What is changed, added or deleted? (Required)

ref https://github.com/tikv/tikv/pull/18994

Update documentation for `storage.flow-control.l0-files-threshold` and `storage.flow-control.soft-pending-compaction-bytes-limit` to reflect the behavior change introduced in TiKV PR #18994.

- **v8.5.4 and earlier**: flow-control config unconditionally overrides the corresponding RocksDB config.
- **From v8.5.5**: flow-control config only overrides when it is smaller than the RocksDB config, to avoid weakening RocksDB's compaction acceleration mechanism when increasing flow-control thresholds.

Also update the corresponding RocksDB config items (`level0-slowdown-writes-trigger`, `soft-pending-compaction-bytes-limit`) with the same version-specific behavior notes.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)

### What is the related PR or file link(s)?

- Related TiKV PR: https://github.com/tikv/tikv/pull/18994

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch