### PR TITLE
dm: add LOCK TABLES privilege note for managed MySQL sources

### DIFF
--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -66,9 +66,13 @@ tiup dmctl check-task ./task.yaml
 
 * （必须）上游数据库的 dump 权限
 
-    - 检查是否有 INFORMATION_SCHEMA 和 dump 表的 SELECT 权限。
-    - 如果 consistency=flush，将检查是否有 RELOAD 权限。
-    - 如果 consistency=flush/lock，将检查是否有 dump 表的 LOCK TABLES 权限。
+    - 检查是否有 `INFORMATION_SCHEMA` 和 dump 表的 `SELECT` 权限。
+    - 如果 `consistency=flush`，将检查是否有 `RELOAD` 权限。
+    - 如果 `consistency=lock`，将检查是否有 dump 表的 `LOCK TABLES` 权限。
+
+    > **注意：**
+    >
+    > 当 `consistency=auto`（默认值）时，DM 会先尝试执行 `FLUSH TABLES WITH READ LOCK` (FTWRL)。如果 FTWRL 不可用，DM 会回退使用 `LOCK TABLES`。这种回退通常发生在托管型 MySQL 服务中，例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL，因为这些服务不允许执行 FTWRL。在这种情况下，运行时需要具备 `LOCK TABLES` 权限，但前置检查当前不会验证该权限。完整的权限列表，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
 
 * （必须）上游 MySQL 多实例分库分表的一致性
 

--- a/dm/dm-precheck.md
+++ b/dm/dm-precheck.md
@@ -72,7 +72,7 @@ tiup dmctl check-task ./task.yaml
 
     > **注意：**
     >
-    > 当 `consistency=auto`（默认值）时，DM 会先尝试执行 `FLUSH TABLES WITH READ LOCK` (FTWRL)。如果 FTWRL 不可用，DM 会回退使用 `LOCK TABLES`。这种回退通常发生在托管型 MySQL 服务中，例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL，因为这些服务不允许执行 FTWRL。在这种情况下，运行时需要具备 `LOCK TABLES` 权限，但前置检查当前不会验证该权限。完整的权限列表，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
+    > 当 `consistency=auto`（默认值）时，DM 会首先尝试执行 `FLUSH TABLES WITH READ LOCK` (FTWRL)。如果 FTWRL 不可用，DM 会回退使用 `LOCK TABLES`。这种回退在托管型 MySQL 服务中较为常见（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 和 Google Cloud SQL），因为这些服务通常不允许执行 FTWRL。在这种情况下，运行时需要具备 `LOCK TABLES` 权限，但当前的 precheck 并不会验证该权限。完整的权限列表，请参见[上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
 
 * （必须）上游 MySQL 多实例分库分表的一致性
 

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -54,7 +54,7 @@ Binlog replication/sync 处理单元读取上游 MySQL/MariaDB 的 binlog event 
 
 > **注意：**
 >
-> 如果从不允许执行 `FLUSH TABLES WITH READ LOCK` (FTWRL) 的托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL）迁移数据，还需要授予 `LOCK TABLES` 权限。使用默认的 `consistency=auto` 设置时，如果 FTWRL 不可用，DM 会回退使用 `LOCK TABLES`。
+> 如果从托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL）迁移数据，且该服务不允许执行 `FLUSH TABLES WITH READ LOCK` (FTWRL)，还需要授予 `LOCK TABLES` 权限。使用默认的 `consistency=auto` 设置时，如果 FTWRL 不可用，DM 会回退到 `LOCK TABLES`。
 
 如果要迁移 `db1` 的数据到 TiDB，可执行如下的 `GRANT` 语句：
 
@@ -65,7 +65,7 @@ GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_w
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
-对于不允许执行 FTWRL 的托管型 MySQL 服务，还需要授予 `LOCK TABLES` 权限：
+对于不允许执行 `FLUSH TABLES WITH READ LOCK` (FTWRL) 的托管型 MySQL 服务，还需要授予 `LOCK TABLES` 权限：
 
 ```sql
 GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';

--- a/dm/dm-worker-intro.md
+++ b/dm/dm-worker-intro.md
@@ -52,6 +52,10 @@ Binlog replication/sync 处理单元读取上游 MySQL/MariaDB 的 binlog event 
 | `REPLICATION SLAVE` | Global |
 | `REPLICATION CLIENT` | Global |
 
+> **注意：**
+>
+> 如果从不允许执行 `FLUSH TABLES WITH READ LOCK` (FTWRL) 的托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL）迁移数据，还需要授予 `LOCK TABLES` 权限。使用默认的 `consistency=auto` 设置时，如果 FTWRL 不可用，DM 会回退使用 `LOCK TABLES`。
+
 如果要迁移 `db1` 的数据到 TiDB，可执行如下的 `GRANT` 语句：
 
 {{< copyable "sql" >}}
@@ -59,6 +63,12 @@ Binlog replication/sync 处理单元读取上游 MySQL/MariaDB 的 binlog event 
 ```sql
 GRANT RELOAD,REPLICATION SLAVE, REPLICATION CLIENT ON *.* TO 'your_user'@'your_wildcard_of_host';
 GRANT SELECT ON db1.* TO 'your_user'@'your_wildcard_of_host';
+```
+
+对于不允许执行 FTWRL 的托管型 MySQL 服务，还需要授予 `LOCK TABLES` 权限：
+
+```sql
+GRANT LOCK TABLES ON db1.* TO 'your_user'@'your_wildcard_of_host';
 ```
 
 如果还要迁移其他数据库的数据到 TiDB，请确保已赋予这些库跟 `db1` 一样的权限。

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -93,7 +93,7 @@ aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-with-dm/','/docs-cn/tidb
 
     > **注意：**
     >
-    > 如果 MySQL 源是托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
+    > 如果你的 MySQL 数据源为托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见[上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
 
 4. 创建示例数据：
 
@@ -154,7 +154,7 @@ aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-with-dm/','/docs-cn/tidb
 
     > **注意：**
     >
-    > 如果 MySQL 源是托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
+    > 如果你的 MySQL 数据源为托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见[上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
 
 6. 创建示例数据：
 

--- a/dm/quick-start-with-dm.md
+++ b/dm/quick-start-with-dm.md
@@ -91,6 +91,10 @@ aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-with-dm/','/docs-cn/tidb
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
 
+    > **注意：**
+    >
+    > 如果 MySQL 源是托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
+
 4. 创建示例数据：
 
     ```sql
@@ -147,6 +151,10 @@ aliases: ['/docs-cn/tidb-data-migration/dev/quick-start-with-dm/','/docs-cn/tidb
 
     GRANT PROCESS, BACKUP_ADMIN, RELOAD, REPLICATION SLAVE, REPLICATION CLIENT, SELECT ON *.* TO 'tidb-dm'@'%';
     ```
+
+    > **注意：**
+    >
+    > 如果 MySQL 源是托管型 MySQL 服务（例如 Amazon RDS、Aurora、ApsaraDB RDS for MySQL、Azure Database for MySQL 或 Google Cloud SQL），还需要授予 `LOCK TABLES` 权限。更多信息，请参见 [DM-worker 上游数据库用户权限](/dm/dm-worker-intro.md#上游数据库用户权限)。
 
 6. 创建示例数据：
 


### PR DESCRIPTION
This PR is translated from: https://github.com/pingcap/docs/pull/22605

### What is changed, added or deleted?

Added conditional `LOCK TABLES` privilege documentation for managed MySQL sources (Amazon RDS, Aurora, Google Cloud SQL) across three DM docs pages.

**Background:** DM defaults to `consistency=auto`. On managed MySQL where `FLUSH TABLES WITH READ LOCK` is restricted by the cloud provider, DM falls back to `LOCK TABLES`. This privilege is not needed on self-managed MySQL instances. Confirmed with @gmhdbjd (Minghao Guo): the FTWRL → LOCK TABLES fallback in `auto` mode is by design.

**Changes:**
- `dm/dm-precheck.md`: Clarified that `LOCK TABLES` is needed for `auto` fallback on managed MySQL, not just `flush/lock`
- `dm/dm-worker-intro.md`: Added `LOCK TABLES` to privilege table with managed-MySQL scope note; added conditional GRANT example
- `dm/quick-start-with-dm.md`: Added note pointing to dm-worker-intro for managed MySQL sources (×2 instances)

**Evidence:** [Lab-06: LOCK TABLES privilege testing](https://github.com/alastori/tidb-sandbox/tree/main/labs/dm/lab-06-lock-tables-privilege) (9 scenarios, vanilla MySQL vs RDS)

**Related:**
- Cloud DM docs: https://github.com/pingcap/docs/pull/22598
- Pre-check improvement: https://tidb.atlassian.net/browse/DM-12687

### Which TiDB version(s) do your changes apply to?

- [x] master (dev)
- [x] v8.5 (LTS)

cc @gmhdbjd @qiancai @OliverS929