### PR TITLE
chore: remove v5.4 from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,6 @@ For details, see [tips for choosing the affected versions (in Chinese)](https://
 - [ ] v7.1 (TiDB 7.1 versions)
 - [ ] v6.5 (TiDB 6.5 versions)
 - [ ] v6.1 (TiDB 6.1 versions)
-- [ ] v5.4 (TiDB 5.4 versions)
 
 ### What is the related PR or file link(s)?
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 | [`release-6.2`](https://github.com/pingcap/docs-cn/tree/release-6.2) | 6.2 开发里程碑版 (DMR)（该版本文档已归档，不再提供任何更新） |
 | [`release-6.1`](https://github.com/pingcap/docs-cn/tree/release-6.1) | 6.1 长期支持版 (LTS) |
 | [`release-6.0`](https://github.com/pingcap/docs-cn/tree/release-6.0) | 6.0 开发里程碑版 (DMR)（该版本文档已归档，不再提供任何更新） |
-| [`release-5.4`](https://github.com/pingcap/docs-cn/tree/release-5.4) | 5.4 稳定版 |
+| [`release-5.4`](https://github.com/pingcap/docs-cn/tree/release-5.4) | 5.4 稳定版 （该版本文档已归档，不再提供任何更新） |
 | [`release-5.3`](https://github.com/pingcap/docs-cn/tree/release-5.3) | 5.3 稳定版 （该版本文档已归档，不再提供任何更新） |
 | [`release-5.2`](https://github.com/pingcap/docs-cn/tree/release-5.2) | 5.2 稳定版 （该版本文档已归档，不再提供任何更新）|
 | [`release-5.1`](https://github.com/pingcap/docs-cn/tree/release-5.1) | 5.1 稳定版 （该版本文档已归档，不再提供任何更新）|


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- remove the `v5.4` checkbox from `.github/pull_request_template.md`
- update `README.md` to mark `release-5.4` documentation as archived and no longer updated

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s):
  - https://github.com/pingcap/docs-cn/pull/18497/files
  - https://github.com/pingcap/docs-staging/pull/133
  - https://github.com/pingcap/docs-staging/pull/134

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
