### PR TITLE
chore: set ResourceCard section toggle for AI docs sync

### DIFF
--- a/.github/workflows/sync-ai-docs-en-to-zh.yml
+++ b/.github/workflows/sync-ai-docs-en-to-zh.yml
@@ -225,6 +225,7 @@ jobs:
           SOURCE_FOLDER: ""
           SOURCE_FILES: ${{ steps.source_files.outputs.files }}
           SOURCE_FILES_TRANSLATION_MODE: ${{ inputs.source_files_translation_mode || 'incremental' }}
+          IGNORE_RESOURCE_CARD_SECTION: "Yes"
           TARGET_REPO_PATH: ${{ github.workspace }}/docs-cn
           AI_PROVIDER: ${{ inputs.ai_provider || 'azure' }}
           TERMS_PATH: ${{ github.workspace }}/docs-source/resources/terms.md


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Add `IGNORE_RESOURCE_CARD_SECTION: "Yes"` to the AI docs EN-to-ZH sync workflow so commit-based sync explicitly skips language-specific `<RelatedResources>` sections containing `<ResourceCard>` by default.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from: N/A
- Other reference link(s): `ai-pr-translator` `IGNORE_RESOURCE_CARD_SECTION` commit-mode option

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
