### PR TITLE
ticdc: update rolling upgrade guidance

### DIFF
--- a/ticdc/deploy-ticdc.md
+++ b/ticdc/deploy-ticdc.md
@@ -98,7 +98,7 @@ tiup cluster upgrade <cluster-name> <version> --transfer-timeout 600
 
 - TiCDC v4.0.2 对 `changefeed` 的配置做了调整，请参阅[配置文件兼容注意事项](/ticdc/ticdc-compatibility.md#命令行参数和配置文件兼容性)。
 - 升级期间遇到的问题及其解决办法，请参阅[使用 TiUP 升级 TiDB](/upgrade-tidb-using-tiup.md#4-升级-faq)。
-- TiCDC 自 v6.3.0 起支持滚动升级，使用 TiUP 升级 TiCDC 节点期间，能够保证同步延迟稳定，不发生剧烈波动。满足以下条件将自动启用滚动升级：
+- TiCDC 自 v6.3.0 起支持滚动升级，但不推荐 TiCDC 老架构在滚动升级的过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
 
     - TiCDC 版本大于等于 v6.3.0。
     - TiUP 版本大于等于 v1.11.3。

--- a/ticdc/deploy-ticdc.md
+++ b/ticdc/deploy-ticdc.md
@@ -98,7 +98,7 @@ tiup cluster upgrade <cluster-name> <version> --transfer-timeout 600
 
 - TiCDC v4.0.2 对 `changefeed` 的配置做了调整，请参阅[配置文件兼容注意事项](/ticdc/ticdc-compatibility.md#命令行参数和配置文件兼容性)。
 - 升级期间遇到的问题及其解决办法，请参阅[使用 TiUP 升级 TiDB](/upgrade-tidb-using-tiup.md#4-升级-faq)。
-- TiCDC 自 v6.3.0 起支持滚动升级，但不推荐 TiCDC 老架构在滚动升级的过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
+- TiCDC 自 v6.3.0 起支持滚动升级，但不推荐 TiCDC 老架构在跨大版本的滚动升级过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级，小版本之间可以直接滚动升级（v8.5.0 -> v8.5.3 属于小版本，v8.1.x -> v8.5.x 属于大版本）。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
 
     - TiCDC 版本大于等于 v6.3.0。
     - TiUP 版本大于等于 v1.11.3。

--- a/ticdc/deploy-ticdc.md
+++ b/ticdc/deploy-ticdc.md
@@ -98,7 +98,7 @@ tiup cluster upgrade <cluster-name> <version> --transfer-timeout 600
 
 - TiCDC v4.0.2 对 `changefeed` 的配置做了调整，请参阅[配置文件兼容注意事项](/ticdc/ticdc-compatibility.md#命令行参数和配置文件兼容性)。
 - 升级期间遇到的问题及其解决办法，请参阅[使用 TiUP 升级 TiDB](/upgrade-tidb-using-tiup.md#4-升级-faq)。
-- TiCDC 自 v6.3.0 起支持滚动升级，小版本之间可以直接滚动升级（v8.5.0 -> v8.5.3 属于小版本，v8.1.x -> v8.5.x 属于大版本）。不推荐 TiCDC 老架构在跨大版本的升级过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
+- TiCDC 自 v6.3.0 起支持滚动升级，小版本之间可以直接滚动升级（v8.5.0 -> v8.5.3 属于小版本，v8.1.x -> v8.5.x 属于大版本）。不推荐 TiCDC 老架构在跨大版本的升级过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级。TiCDC 新架构支持在滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
 
     - TiCDC 版本大于等于 v6.3.0。
     - TiUP 版本大于等于 v1.11.3。

--- a/ticdc/deploy-ticdc.md
+++ b/ticdc/deploy-ticdc.md
@@ -98,7 +98,7 @@ tiup cluster upgrade <cluster-name> <version> --transfer-timeout 600
 
 - TiCDC v4.0.2 对 `changefeed` 的配置做了调整，请参阅[配置文件兼容注意事项](/ticdc/ticdc-compatibility.md#命令行参数和配置文件兼容性)。
 - 升级期间遇到的问题及其解决办法，请参阅[使用 TiUP 升级 TiDB](/upgrade-tidb-using-tiup.md#4-升级-faq)。
-- TiCDC 自 v6.3.0 起支持滚动升级，但不推荐 TiCDC 老架构在跨大版本的滚动升级过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级，小版本之间可以直接滚动升级（v8.5.0 -> v8.5.3 属于小版本，v8.1.x -> v8.5.x 属于大版本）。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
+- TiCDC 自 v6.3.0 起支持滚动升级，小版本之间可以直接滚动升级（v8.5.0 -> v8.5.3 属于小版本，v8.1.x -> v8.5.x 属于大版本）。不推荐 TiCDC 老架构在跨大版本的升级过程中运行 Changefeed，建议暂停 Changefeed 再做 TiCDC 老架构的升级。TiCDC 新架构支持滚动升级的过程中运行 Changefeed。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。满足以下条件将自动启用滚动升级：
 
     - TiCDC 版本大于等于 v6.3.0。
     - TiUP 版本大于等于 v1.11.3。

--- a/ticdc/ticdc-compatibility.md
+++ b/ticdc/ticdc-compatibility.md
@@ -43,7 +43,9 @@ TiCDC 依赖 TiDB、TiKV 和 PD 提供的上游变更数据及相关接口。随
 
 ### 老架构 TiCDC 升级建议
 
-对于老架构 TiCDC，**不建议在 TiDB 集群滚动升级期间持续运行 Changefeed**。升级时，建议按以下顺序执行：
+如果将老架构 TiCDC 升级到新架构，需要先暂停所有 Changefeed 再做升级，更多说明请参阅 [TiCDC 新架构升级指南](/ticdc/ticdc-architecture.md#升级指南)。
+
+如果是老架构 TiCDC 之间的升级，小版本之间可以正常滚动升级；如果是跨大版本升级（v8.5.0 -> v8.5.3 属于跨小版本，v8.1.x -> v8.5.x 属于跨大版本），**不建议在 TiDB 集群滚动升级期间持续运行 Changefeed**。需要跨大版本升级时，建议按以下顺序执行：
 
 1. 暂停所有 Changefeed。
 2. 滚动升级 TiDB 集群。

--- a/ticdc/ticdc-compatibility.md
+++ b/ticdc/ticdc-compatibility.md
@@ -43,7 +43,7 @@ TiCDC 依赖 TiDB、TiKV 和 PD 提供的上游变更数据及相关接口。随
 
 ### 老架构 TiCDC 升级建议
 
-如果将老架构 TiCDC 升级到新架构，需要先暂停所有 Changefeed 再做升级，更多说明请参阅 [TiCDC 新架构升级指南](/ticdc/ticdc-architecture.md#升级指南)。
+如果将老架构 TiCDC 升级到新架构，需要先暂停所有 Changefeed 再做升级。更多说明请参阅 [TiCDC 新架构升级指南](/ticdc/ticdc-architecture.md#升级指南)。
 
 如果是老架构 TiCDC 之间的升级，小版本之间可以正常滚动升级；如果是跨大版本升级（v8.5.0 -> v8.5.3 属于跨小版本，v8.1.x -> v8.5.x 属于跨大版本），**不建议在 TiDB 集群滚动升级期间持续运行 Changefeed**。需要跨大版本升级时，建议按以下顺序执行：
 

--- a/ticdc/ticdc-compatibility.md
+++ b/ticdc/ticdc-compatibility.md
@@ -43,12 +43,11 @@ TiCDC 依赖 TiDB、TiKV 和 PD 提供的上游变更数据及相关接口。随
 
 ### 老架构 TiCDC 升级建议
 
-对于老架构 TiCDC，**不建议在 TiDB 滚动升级期间持续运行 Changefeed**。升级时，建议按以下顺序执行：
+对于老架构 TiCDC，**不建议在 TiDB 集群滚动升级期间持续运行 Changefeed**。升级时，建议按以下顺序执行：
 
 1. 暂停所有 Changefeed。
-2. 先升级 TiCDC。
-3. 再升级 TiDB 集群中的其他组件。
-4. 升级完成后，恢复 Changefeed。
+2. 滚动升级 TiDB 集群。
+3. 升级完成后，恢复 Changefeed。
 
 例如，假设将集群从 v8.5.4 升级到 v8.5.5，如果使用 TiUP 管理集群，可以参考以下命令（以下示例以 `linux-amd64` 为例，其他平台请根据实际环境替换包名中的平台信息）：
 
@@ -58,35 +57,14 @@ tiup cdc:v8.5.4 cli changefeed pause \
   --server=http://<ticdc-host>:8300 \
   --changefeed-id=<changefeed-id>
 
-# 2. 先升级 TiCDC。
-wget https://tiup-mirrors.pingcap.com/cdc-v8.5.5-linux-amd64.tar.gz \
-  -O /tmp/cdc-v8.5.5-linux-amd64.tar.gz
-tiup cluster patch <cluster-name> /tmp/cdc-v8.5.5-linux-amd64.tar.gz -R cdc
+# 2. 滚动升级 TiDB 集群。
+tiup cluster upgrade <cluster-name> v8.5.5
 
-# 3. 再升级 TiDB 集群中的其他组件。
-#    需根据集群中实际存在的组件分别执行。以下示例包括 PD、TiKV 和 TiDB。
-wget https://tiup-mirrors.pingcap.com/pd-v8.5.5-linux-amd64.tar.gz \
-  -O /tmp/pd-v8.5.5-linux-amd64.tar.gz
-wget https://tiup-mirrors.pingcap.com/tikv-v8.5.5-linux-amd64.tar.gz \
-  -O /tmp/tikv-v8.5.5-linux-amd64.tar.gz
-wget https://tiup-mirrors.pingcap.com/tidb-v8.5.5-linux-amd64.tar.gz \
-  -O /tmp/tidb-v8.5.5-linux-amd64.tar.gz
-
-tiup cluster patch <cluster-name> /tmp/pd-v8.5.5-linux-amd64.tar.gz -R pd
-tiup cluster patch <cluster-name> /tmp/tikv-v8.5.5-linux-amd64.tar.gz -R tikv
-tiup cluster patch <cluster-name> /tmp/tidb-v8.5.5-linux-amd64.tar.gz -R tidb
-
-# 如果集群中还包含 TiFlash、TiProxy、TiKV-CDC 等组件，也需按相同方式分别执行 patch。
-
-# 4. 升级完成后，恢复所有 Changefeed（需对每个 Changefeed 分别执行一次）。
+# 3. 升级完成后，恢复所有 Changefeed（需对每个 Changefeed 分别执行一次）。
 tiup cdc:v8.5.5 cli changefeed resume \
   --server=http://<ticdc-host>:8300 \
   --changefeed-id=<changefeed-id>
 ```
-
-> **注意：**
->
-> `tiup cluster patch` 每次只能替换一个组件，因此第 3 步需要根据集群中实际存在的组件分别执行。
 
 ### 新架构 TiCDC 升级建议
 

--- a/upgrade-tidb-using-tiup.md
+++ b/upgrade-tidb-using-tiup.md
@@ -50,7 +50,7 @@ summary: TiUP 可用于 TiDB 升级。升级过程中需注意不支持 TiFlash 
 
 - TiDB 目前暂不支持版本降级或升级后回退。
 - 支持 TiCDC，TiFlash 等组件版本的升级。
-- 如果集群中包含基于老架构的 TiCDC 历史版本（例如 `v8.1.2`），不建议在 TiDB 滚动升级期间持续运行 Changefeed。若目标 TiDB 版本高于老架构 TiCDC，必须先升级 TiCDC。升级的时候，建议按“暂停所有 Changefeed -> 升级 TiCDC -> 升级 TiDB 集群 -> 恢复 Changefeed”的顺序执行。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。
+- 如果集群中包含基于老架构的 TiCDC 历史版本（例如 `v8.1.2`），不建议在跨大版本升级期间持续运行 Changefeed。升级的时候，建议按“暂停所有 Changefeed -> 升级 TiCDC -> 升级 TiDB 集群 -> 恢复 Changefeed”的顺序执行。更多说明请参考 [TiCDC 历史版本滚动升级兼容性说明](/ticdc/ticdc-compatibility.md#历史版本升级的兼容性说明)。
 - 将 v6.3.0 之前的 TiFlash 升级至 v6.3.0 及之后的版本时，需要特别注意：在 Linux AMD64 架构的硬件平台部署 TiFlash 时，CPU 必须支持 AVX2 指令集。而在 Linux ARM64 架构的硬件平台部署 TiFlash 时，CPU 必须支持 ARMv8 架构。具体请参考 [6.3.0 版本 Release Notes](/releases/release-6.3.0.md#其他) 中的描述。
 - 具体不同版本的兼容性说明，请查看各个版本的 [Release Note](/releases/_index.md)。请根据各个版本的 Release Note 的兼容性更改调整集群的配置。
 - 升级 v5.3 之前版本的集群到 v5.3 及后续版本时，默认部署的 Prometheus 生成的 Alert 存在时间格式变化。该格式变化是从 Prometheus v2.27.1 开始引入的，详情见 [Prometheus commit](https://github.com/prometheus/prometheus/commit/7646cbca328278585be15fa615e22f2a50b47d06)。


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update TiCDC rolling-upgrade guidance for old-architecture TiCDC:

- Clarify that old-architecture TiCDC should pause Changefeeds during TiDB cluster rolling upgrades.
- Replace the per-component `tiup cluster patch` example with `tiup cluster upgrade`.
- Clarify old/new architecture behavior in the deployment guide and link to the compatibility notes.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs-cn/pull/21496

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [x] Might cause conflicts after applied to another branch
