### PR TITLE
pdf: remove StickyHeaderTable tags before PDF generation

### DIFF
--- a/scripts/merge_by_toc.py
+++ b/scripts/merge_by_toc.py
@@ -192,6 +192,26 @@ def replace_heading_func(diff_level=0):
 
     return replace_heading
 
+# remove <StickyHeaderTable> / </StickyHeaderTable> tags for PDF output
+sticky_header_table_pattern = re.compile(r'^\s*</?StickyHeaderTable>\s*$')
+
+def remove_sticky_header_table(text):
+    lines = text.split('\n')
+    result = []
+    i = 0
+    while i < len(lines):
+        if sticky_header_table_pattern.match(lines[i]):
+            prev_blank = len(result) > 0 and result[-1].strip() == ''
+            next_blank = i + 1 < len(lines) and lines[i + 1].strip() == ''
+            if prev_blank and next_blank:
+                i += 2
+            else:
+                i += 1
+        else:
+            result.append(lines[i])
+            i += 1
+    return '\n'.join(result)
+
 # remove copyable snippet code
 def remove_copyable(match):
     return ''
@@ -213,6 +233,7 @@ for type_, level, name in followups:
                 chapter = replace_variables(chapter, variables)
                 chapter = replace_link_wrap(chapter, name)
                 chapter = copyable_snippet_pattern.sub(remove_copyable, chapter)
+                chapter = remove_sticky_header_table(chapter)
                 chapter = extract_custom_ids_and_clean(chapter)
                 chapter = replace_custom_id_links(chapter)
 

--- a/scripts/merge_by_toc.py
+++ b/scripts/merge_by_toc.py
@@ -193,7 +193,7 @@ def replace_heading_func(diff_level=0):
     return replace_heading
 
 # remove <StickyHeaderTable> / </StickyHeaderTable> tags for PDF output
-sticky_header_table_pattern = re.compile(r'^\s*</?StickyHeaderTable>\s*$')
+sticky_header_table_pattern = re.compile(r'^\s*</?StickyHeaderTable\s*/?>\s*$')
 
 def remove_sticky_header_table(text):
     lines = text.split('\n')
@@ -211,6 +211,7 @@ def remove_sticky_header_table(text):
             result.append(lines[i])
             i += 1
     return '\n'.join(result)
+
 
 # remove copyable snippet code
 def remove_copyable(match):


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

- Remove standalone `<StickyHeaderTable>` and `</StickyHeaderTable>` lines before PDF generation.
- If either tag is surrounded by blank lines, remove the blank line after the tag together with the tag line, so the merged Markdown does not leave extra empty rows that affect PDF rendering.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/22970
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch