### PR TITLE
docs: fix incomplete SHOW CREATE statement to SHOW CREATE TABLE

### DIFF
--- a/basic-sql-operations.md
+++ b/basic-sql-operations.md
@@ -99,7 +99,7 @@ CREATE TABLE person (
     );
 ```
 
-使用 `SHOW CREATE` 语句查看建表语句，即 DDL。例如：
+使用 `SHOW CREATE TABLE` 语句查看建表语句，即 DDL。例如：
 
 {{< copyable "sql" >}}
 


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation.-->

### What is changed, added or deleted?

Fixed an incomplete SQL statement reference in . The text described using the "SHOW CREATE" statement, which is not a valid standalone SQL command. The correct statement is "SHOW CREATE TABLE".

### Which TiDB version(s) do your changes apply to?

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/23023 N/A
- Other reference link(s):
  - The Japanese translation (i18n-ja-release-8.5 branch) identified this issue during Phase 1 translation quality review: https://github.com/pingcap/docs/pull/23022