### PR TITLE
doc: Capitalize 'Parquet' consistently to prevent mistranslation

### DIFF
--- a/migrate-aurora-to-tidb.md
+++ b/migrate-aurora-to-tidb.md
@@ -133,7 +133,7 @@ sorted-kv-dir = "${path}"
 data-source-dir = "s3://my-bucket/sql-backup"
 
 [[mydumper.files]]
-# 解析 parquet 文件所需的表达式
+# 解析 Parquet 文件所需的表达式
 pattern = '(?i)^(?:[^/]*/)*([a-z0-9_]+)\.([a-z0-9_]+)/(?:[^/]*/)*(?:[a-z0-9\-_.]+\.(parquet))$'
 schema = '$1'
 table = '$2'

--- a/migrate-from-parquet-files-to-tidb.md
+++ b/migrate-from-parquet-files-to-tidb.md
@@ -16,7 +16,7 @@ summary: 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiD
 
 ## 第 1 步：准备 Parquet 文件
 
-本节描述如何从 Hive 中导出 Parquet 文件，以便 TiDB Lightning 可以读取这些文件。
+本节描述如何从 Hive 中导出能被 TiDB Lightning 读取的 Parquet 文件。
 
 你可以通过指定 `STORED AS PARQUET LOCATION '/path/in/hdfs'` 将 Hive 中的每个表导出为 Parquet 文件。因此，如果你需要导出一张名叫 `test` 的表，请执行以下步骤：
 
@@ -41,13 +41,13 @@ summary: 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiD
     DROP TABLE temp;
     ```
 
-3. 从 Hive 导出的 Parquet 文件可能不带有 `.parquet` 后缀，因此 TiDB Lightning 无法正确识别这些文件。因此，在进行导入之前，需要对这些文件进行重命名，添加 `.parquet` 后缀，将完整的文件名修改为 TiDB Lightning 能识别的格式，例如 `${db_name}.${table_name}.parquet`。更多文件类型和命名规则，请参考 [TiDB Lightning 数据源](/tidb-lightning/tidb-lightning-data-source.md)。你也可以通过设置正确的[自定义表达式](/tidb-lightning/tidb-lightning-data-source.md#自定义文件匹配)匹配数据文件。
+3. 从 Hive 导出的 Parquet 文件可能不带有 `.parquet` 后缀，因此 TiDB Lightning 无法正确识别这些文件。在进行导入之前，需要对这些文件进行重命名，添加 `.parquet` 后缀，将完整的文件名修改为 TiDB Lightning 能识别的格式，例如 `${db_name}.${table_name}.parquet`。更多文件类型和命名规则，请参考 [TiDB Lightning 数据源](/tidb-lightning/tidb-lightning-data-source.md)。你也可以通过设置正确的[自定义表达式](/tidb-lightning/tidb-lightning-data-source.md#自定义文件匹配)匹配数据文件。
 
-4. 将所有 Parquet 文件放到统一目录下，例如 `/data/my_datasource/` 或 `s3://my-bucket/sql-backup`。TiDB Lightning 递归搜索该目录及其子目录内的所有 `.parquet` 文件。
+4. 将所有 Parquet 文件放到统一目录下，例如 `/data/my_datasource/` 或 `s3://my-bucket/sql-backup`。TiDB Lightning 将递归搜索该目录及其子目录内的所有 `.parquet` 文件。
 
 ## 第 2 步：创建目标表结构
 
-在将 Parquet 文件中的数据导入 TiDB 前，你需要创建目标表结构。你可以通过以下两种方法之一创建目标表结构：
+在将 Parquet 文件导入 TiDB 前，你必须为 Parquet 文件提供表结构。你可以通过以下任一方法创建表结构：
 
 * **方法一**：使用 TiDB Lightning 创建表结构。
 

--- a/migrate-from-parquet-files-to-tidb.md
+++ b/migrate-from-parquet-files-to-tidb.md
@@ -16,9 +16,9 @@ summary: 介绍如何使用 TiDB Lightning 从 Parquet 文件迁移数据到 TiD
 
 ## 第 1 步：准备 Parquet 文件
 
-本节描述如何从 Hive 中导出能被 TiDB Lightning 读取的 Parquet 文件。
+本节描述如何从 Hive 中导出 Parquet 文件，以便 TiDB Lightning 可以读取这些文件。
 
-Hive 中每个表都能通过标注 `STORED AS PARQUET LOCATION '/path/in/hdfs'` 的形式将表数据导出到 Parquet 文件中。因此，如果你需要导出一张名叫 `test` 的表，请执行以下步骤：
+你可以通过指定 `STORED AS PARQUET LOCATION '/path/in/hdfs'` 将 Hive 中的每个表导出为 Parquet 文件。因此，如果你需要导出一张名叫 `test` 的表，请执行以下步骤：
 
 1. 在 Hive 中执行如下 SQL 语句：
 
@@ -41,13 +41,13 @@ Hive 中每个表都能通过标注 `STORED AS PARQUET LOCATION '/path/in/hdfs'`
     DROP TABLE temp;
     ```
 
-3. 从 Hive 导出的 Parquet 文件可能不带有 `.parquet` 的后缀，无法被 TiDB Lightning 正确识别。因此，在进行导入之前，需要对导出的文件进行重命名，添加 `.parquet` 后缀，将完整的文件名修改为 TiDB Lightning 能识别的格式 `${db_name}.${table_name}.parquet`。更多文件类型和命名规则，请参考 [TiDB Lightning 数据源](/tidb-lightning/tidb-lightning-data-source.md)。你也可以通过设置正确的[自定义表达式](/tidb-lightning/tidb-lightning-data-source.md#自定义文件匹配)匹配数据文件。
+3. 从 Hive 导出的 Parquet 文件可能不带有 `.parquet` 后缀，因此 TiDB Lightning 无法正确识别这些文件。因此，在进行导入之前，需要对这些文件进行重命名，添加 `.parquet` 后缀，将完整的文件名修改为 TiDB Lightning 能识别的格式，例如 `${db_name}.${table_name}.parquet`。更多文件类型和命名规则，请参考 [TiDB Lightning 数据源](/tidb-lightning/tidb-lightning-data-source.md)。你也可以通过设置正确的[自定义表达式](/tidb-lightning/tidb-lightning-data-source.md#自定义文件匹配)匹配数据文件。
 
-4. 将所有 Parquet 文件放到统一目录下，例如 `/data/my_datasource/` 或 `s3://my-bucket/sql-backup`。TiDB Lightning 将递归地寻找该目录及其子目录内的所有 `.parquet` 文件。
+4. 将所有 Parquet 文件放到统一目录下，例如 `/data/my_datasource/` 或 `s3://my-bucket/sql-backup`。TiDB Lightning 递归搜索该目录及其子目录内的所有 `.parquet` 文件。
 
 ## 第 2 步：创建目标表结构
 
-在将 Parquet 文件导入 TiDB 前，你必须为 Parquet 文件提供表结构。你可以通过以下任一方法创建表结构：
+在将 Parquet 文件中的数据导入 TiDB 前，你需要创建目标表结构。你可以通过以下两种方法之一创建目标表结构：
 
 * **方法一**：使用 TiDB Lightning 创建表结构。
 


### PR DESCRIPTION
This PR is translated from: https://github.com/pingcap/docs/pull/23038

### What is changed and how it works?

This PR capitalizes the word "parquet" to "Parquet" consistently in the documentation to achieve two purposes:

1. **Prevent mistranslation**: The Japanese i18n team encountered a severe machine translation error where "parquet" was mistranslated as "寄木細工" (wooden flooring) instead of the Apache Parquet file format. Capitalizing the proper noun helps MT engines and human translators recognize it as a proper noun (file format name) rather than a common English word.

2. **Use the official name**: Apache Parquet is a proper noun and a trademarked file format name. According to the Apache Parquet project and general technical writing conventions, proper nouns should be capitalized.

### Changed files
- : Capitalized all occurrences of "parquet files" in body text to "Parquet files"
- : Capitalized "parquet file" in code comment to "Parquet file"

Note: File extensions () remain lowercase as they are file name conventions, not the format name.

### Check List

- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
- [x] TiDB Cloud / TiDB documentation
- [x] English / Japanese documentation
- [x] No need for documentation update (this is a style/translation fix)

### Release note

- None