### PR TITLE
br: reword 'Base64-encoded storage' for accurate machine translation

### DIFF
--- a/br/br-compact-log-backup.md
+++ b/br/br-compact-log-backup.md
@@ -53,7 +53,7 @@ br operator base64ify --storage "s3://your/log/backup/storage/here" --load-creds
 
 #### 第 2 步：执行日志压缩
 
-获得上一步中的 Base64 编码字符串后，你可以使用 `tikv-ctl` 开始压缩。默认情况下，`tikv-ctl` 的日志等级为 `warning`。使用 `--log-level info` 可获取更详细的信息：
+获得上一步中的 Base64 编码字符串后，你可以使用 `tikv-ctl` 开始执行压缩。默认情况下，`tikv-ctl` 的日志等级为 `warning`。使用 `--log-level info` 可获取更详细的信息：
 
 ```shell
 tikv-ctl --log-level info compact-log-backup \

--- a/br/br-compact-log-backup.md
+++ b/br/br-compact-log-backup.md
@@ -49,11 +49,11 @@ br operator base64ify --storage "s3://your/log/backup/storage/here" --load-creds
 > **注意：**
 >
 > - 如果执行以上命令时带了 `--load-cerds` 这个选项，编码出来的 Base64 中会包含从 BR 当前环境中加载的密钥信息，请注意安全保护和权限管控。
-> - 此处的 `--storage` 值应该和日志备份任务的 `log status` 命令输出的 storage 相同。
+> - 此处的 `--storage` 值应该与日志备份任务的 `log status` 命令输出相匹配。
 
 #### 第 2 步：执行日志压缩
 
-有了存储的 Base64 之后，你可以执行以下命令通过 `tikv-ctl` 发起压缩，注意 `tikv-ctl` 默认日志等级为 `warning`，启用 `--log-level info` 来获得更多信息：
+获得上一步中的 Base64 编码字符串后，你可以使用 `tikv-ctl` 开始压缩。默认情况下，`tikv-ctl` 的日志等级为 `warning`。使用 `--log-level info` 可获取更详细的信息：
 
 ```shell
 tikv-ctl --log-level info compact-log-backup \
@@ -63,7 +63,7 @@ tikv-ctl --log-level info compact-log-backup \
 
 参数解释如下：
 
-- `-s`：已获得的存储的 Base64。
+- `-s`：上一步中获得的 Base64 编码字符串。
 - `-N`：最大并发压缩日志任务的数量。
 - `--from`：压缩开始的时间戳。
 - `--until`：压缩结束的时间戳。


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

This PR rewords ambiguous English phrases in `br/br-compact-log-backup.md` to produce more accurate machine translations to Japanese.

**Problem:**
The original English text contains the phrase "Base64-encoded storage", which machine translators (and human translators) interpret as "storage itself being Base64-encoded". This leads to unnatural Japanese translations like "Base64エンコードストレージ" (Base64-encoded storage), which is confusing because what is actually encoded is the storage URI/string, not the storage.

The root cause traces back to the Chinese source phrase "有了存储的 Base64" (the Base64 of the storage / the storage's Base64), which was translated to English as "Base64-encoded storage" — reversing the possessive relationship and changing the meaning.

**Changes:**
| Before | After | Why |
|--------|-------|-----|
| "matches the storage output" | "should match the output" | "storage output" is a confusing compound noun that MT renders literally as "storage出力" |
| "With the Base64-encoded storage, you can initiate the compaction..." | "Once you have the Base64-encoded string from the previous step, you can start compaction..." | Clarifies that the **string** (not the storage) was encoded; "initiate the compaction" is also overly formal |
| "the Base64-encoded storage string obtained earlier" | "the Base64-encoded string obtained in the previous step" | Same compound-noun ambiguity as above |

These changes ensure machine translation produces natural Japanese: e.g., "Base64エンコードされた文字列" instead of the nonsensical "Base64エンコードストレージ".

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/23047
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch