### PR TITLE
pessimistic-transaction: clarify Point Get lock behavior for non-existing keys under different isolation levels

### DIFF
--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -77,7 +77,7 @@ BEGIN /*T! PESSIMISTIC */;
 
     > **注意：**
     >
-    > 此行为仅适用于 [Repeatable Read](/transaction-isolation-levels.md#repeatable-read-isolation-level) 隔离级别。在 `READ COMMITTED` 隔离级别下，`Point Get` 和 `Batch Point Get` 算子不会对不存在的键加锁。
+    > 此行为仅适用于 [可重复读 (Repeatable Read)](/transaction-isolation-levels.md#可重复读隔离级别-repeatable-read) 隔离级别。在 [读已提交 (Read Committed)](/transaction-isolation-levels.md#读已提交隔离级别-read-committed) 隔离级别下，`Point Get` 和 `Batch Point Get` 算子不会对不存在的键加锁。
 
 - 支持 `FOR UPDATE OF TABLES` 语法，对于存在多表 join 的语句，只对 `OF TABLES` 中包含的表关联的行进行悲观锁加锁操作。
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -77,7 +77,7 @@ BEGIN /*T! PESSIMISTIC */;
 
     > **注意：**
     >
-    > 此行为仅适用于 [可重复读 (Repeatable Read)](/transaction-isolation-levels.md#可重复读隔离级别-repeatable-read) 隔离级别。在 [读已提交 (Read Committed)](/transaction-isolation-levels.md#读已提交隔离级别-read-committed) 隔离级别下，`Point Get` 和 `Batch Point Get` 算子不会对不存在的键加锁。
+    > 此行为仅适用于[可重复读 (Repeatable Read)](/transaction-isolation-levels.md#可重复读隔离级别-repeatable-read) 隔离级别。在[读已提交 (Read Committed)](/transaction-isolation-levels.md#读已提交隔离级别-read-committed) 隔离级别下，`Point Get` 和 `Batch Point Get` 算子不会对不存在的键加锁。
 
 - 支持 `FOR UPDATE OF TABLES` 语法，对于存在多表 join 的语句，只对 `OF TABLES` 中包含的表关联的行进行悲观锁加锁操作。
 

--- a/pessimistic-transaction.md
+++ b/pessimistic-transaction.md
@@ -75,7 +75,11 @@ BEGIN /*T! PESSIMISTIC */;
 
 - 如果 `Point Get` 和 `Batch Point Get` 算子没有读到数据，依然会对给定的主键或者唯一键加锁，阻塞其他事务对相同主键唯一键加锁或者进行写入操作。
 
-- 支持 `FOR UPDATE OF TABLES` 语法，对于存在多表 join 的语句，只对 `OF TABLES` 中包含的表关联的行进行悲观锁加锁操作。 
+    > **注意：**
+    >
+    > 此行为仅适用于 [Repeatable Read](/transaction-isolation-levels.md#repeatable-read-isolation-level) 隔离级别。在 `READ COMMITTED` 隔离级别下，`Point Get` 和 `Batch Point Get` 算子不会对不存在的键加锁。
+
+- 支持 `FOR UPDATE OF TABLES` 语法，对于存在多表 join 的语句，只对 `OF TABLES` 中包含的表关联的行进行悲观锁加锁操作。
 
 ## 和 MySQL InnoDB 的差异
 


### PR DESCRIPTION
This PR is translated from: https://github.com/pingcap/docs/pull/23111

### What is changed, added or deleted? (Required)

Added a **Note** in the `Behaviors` section of `pessimistic-transaction.md` to clarify that the Point Get and Batch Point Get lock behavior for non-existing keys applies **only to the `REPEATABLE READ` isolation level**.

Under the `READ COMMITTED` isolation level, `Point Get` and `Batch Point Get` operators do **not** lock non-existent keys. This is a behavioral difference that can affect applications using `SELECT FOR UPDATE` for existence checks followed by `INSERT`.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- Related documentation: https://docs.pingcap.com/tidbcloud/pessimistic-transaction/#behaviors

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [x] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch

### Verification

This behavior was verified on TiDB v8.5.3:

| # | Access Method | Isolation Level | Non-existing Key | Lock Acquired? |
|---|---------------|-----------------|------------------|----------------|
| 1 | Point Get | Repeatable Read | `id = 999` | **Yes** |
| 2 | Point Get | Read Committed | `id = 888` | **No** |
| 3 | Batch Point Get | Repeatable Read | `id IN (777, 888)` | **Yes** |
| 4 | Range Scan | Repeatable Read | `id BETWEEN 100 AND 200` | **No** (no gap lock) |

A test script was provided in the PR comments for reviewers to verify the behavior locally.