### PR TITLE
config: fix heading hierarchy for sub-section levels in tidb-configuration-file.md

### DIFF
--- a/tidb-configuration-file.md
+++ b/tidb-configuration-file.md
@@ -346,7 +346,7 @@ TiDB 配置文件比命令行参数支持更多的选项。你可以在 [config/
 + 单位：秒
 + 在某些用户场景中，TiDB 日志可能是保存在热插拔盘或网络挂载盘上，这些磁盘可能会永久丢失。在这种场景下，TiDB 无法自动恢复，写日志操作会永久阻塞。尽管 TiDB 进程看起来仍在运行，但不会响应任何请求。该配置项用于处理这样的场景。
 
-## log.file
+### log.file
 
 日志文件相关的配置项。
 
@@ -656,17 +656,17 @@ opentracing 的相关的设置。
 + 开启 rpc metrics。
 + 默认值：false
 
-## opentracing.sampler
+### opentracing.sampler
 
 opentracing.sampler 相关的设置。
 
-### `type`
+#### `type`
 
 + opentracing 采样器的类型。字符串取值大小写不敏感。
 + 默认值："const"
 + 可选值："const"，"probabilistic"，"ratelimiting"，remote"
 
-### `param`
+#### `param`
 
 + 采样器参数。
     - 对于 const 类型，可选值为 0 或 1，表示是否开启。
@@ -675,41 +675,41 @@ opentracing.sampler 相关的设置。
     - 对于 remote 类型，参数为采样概率，可选值为 0 到 1 之间的浮点数。
 + 默认值：1.0
 
-### `sampling-server-url`
+#### `sampling-server-url`
 
 + jaeger-agent 采样服务器的 HTTP URL 地址。
 + 默认值：""
 
-### `max-operations`
+#### `max-operations`
 
 + 采样器可追踪的最大操作数。如果一个操作没有被追踪，会启用默认的 probabilistic 采样器。
 + 默认值：0
 
-### `sampling-refresh-interval`
+#### `sampling-refresh-interval`
 
 + 控制远程轮询 jaeger-agent 采样策略的频率。
 + 默认值：0
 
-## opentracing.reporter
+### opentracing.reporter
 
 opentracing.reporter 相关的设置。
 
-### `queue-size`
+#### `queue-size`
 
 + reporter 在内存中记录 spans 个数的队列容量。
 + 默认值：0
 
-### `buffer-flush-interval`
+#### `buffer-flush-interval`
 
 + reporter 缓冲区的刷新频率。
 + 默认值：0
 
-### `log-spans`
+#### `log-spans`
 
 + 是否为所有提交的 span 打印日志。
 + 默认值：false
 
-### `local-agent-host-port`
+#### `local-agent-host-port`
 
 + reporter 向 jaeger-agent 发送 span 的地址。
 + 默认值：""
@@ -810,11 +810,11 @@ opentracing.reporter 相关的设置。
 + 用于控制给 TiKV 发送 RPC 请求时，是否使用新版本的 Region 副本选择器。
 + 默认值：true
 
-## tikv-client.copr-cache <span class="version-mark">从 v4.0.0 版本开始引入</span>
+### tikv-client.copr-cache <span class="version-mark">从 v4.0.0 版本开始引入</span>
 
 本部分介绍 [Coprocessor Cache](/coprocessor-cache.md) 相关的配置项。
 
-### `capacity-mb`
+#### `capacity-mb`
 
 + 缓存的总数据量大小。当缓存空间满时，旧缓存条目将被逐出。值为 0.0 时表示关闭 Coprocessor Cache。
 + 默认值：1000.0


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Fix heading hierarchy in tidb-configuration-file.md for sub-section levels that incorrectly used `##` instead of `###`:

- `## log.file` → `### log.file` (child of `## log`)
- `## opentracing.sampler` → `### opentracing.sampler` (child of `## opentracing`)
- `## opentracing.reporter` → `### opentracing.reporter` (child of `## opentracing`)
- `## tikv-client.copr-cache` → `### tikv-client.copr-cache` (child of `## tikv-client`)

These dotted config key names indicate they belong to parent sections, so they should be rendered as sub-headings.

### Which TiDB version(s) do your changes apply to? (Required)

- [ ] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)
- [ ] v5.4 (TiDB 5.4 versions)
- [ ] v5.3 (TiDB 5.3 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/23160
- Other reference link(s):

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
