### PR TITLE
docs: clarify max-ts max-drift constraint

### DIFF
--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -662,7 +662,8 @@ I/O rate limiter 相关的配置项。
 + 定义当读写请求使用的 TS 超过 TiKV 缓存的 PD TSO 时，所允许的最长超出时间。
 + 如果某个读写请求使用的 TS 超过了 TiKV 缓存的 PD TSO + `max-drift`，TiKV 会将其视为非法的 `max-ts` 更新请求，并根据 [`action-on-invalid-update`](#action-on-invalid-update-从-v900-版本开始引入) 的配置进行处理。
 + 默认值：`"60s"`
-+ 该值必须大于 [`cache-sync-interval`](#cache-sync-interval-从-v900-版本开始引入)，否则 TiKV 会拒绝加载配置。建议设置为 `cache-sync-interval` 的 3 倍以上。
++ 该值必须大于 [`cache-sync-interval`](#cache-sync-interval-从-v900-版本开始引入)，否则 TiKV 校验配置会失败并拒绝启动。
++ 建议设置为 [`cache-sync-interval`](#cache-sync-interval-从-v900-版本开始引入) 的 3 倍以上。
 
 ## pd
 

--- a/tikv-configuration-file.md
+++ b/tikv-configuration-file.md
@@ -662,7 +662,7 @@ I/O rate limiter 相关的配置项。
 + 定义当读写请求使用的 TS 超过 TiKV 缓存的 PD TSO 时，所允许的最长超出时间。
 + 如果某个读写请求使用的 TS 超过了 TiKV 缓存的 PD TSO + `max-drift`，TiKV 会将其视为非法的 `max-ts` 更新请求，并根据 [`action-on-invalid-update`](#action-on-invalid-update-从-v900-版本开始引入) 的配置进行处理。
 + 默认值：`"60s"`
-+ 建议设置为 [`cache-sync-interval`](#cache-sync-interval-从-v900-版本开始引入) 的 3 倍以上。
++ 该值必须大于 [`cache-sync-interval`](#cache-sync-interval-从-v900-版本开始引入)，否则 TiKV 会拒绝加载配置。建议设置为 `cache-sync-interval` 的 3 倍以上。
 
 ## pd
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Clarify that `storage.max-ts.max-drift` must be greater than `cache-sync-interval`, otherwise TiKV rejects the configuration.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- Other reference link(s): https://github.com/pingcap/docs-cn/pull/21745#discussion_r3472460846

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
