### PR TITLE
master: handle referenced image changes in AI docs sync

### DIFF
--- a/.github/workflows/sync-ai-docs-en-to-zh.yml
+++ b/.github/workflows/sync-ai-docs-en-to-zh.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       file_names:
-        description: "Specify files to translate under docs/ai or TOC-ai.md (comma-separated list)"
+        description: "Specify files to translate under docs/ai, TOC-ai.md, or referenced image paths (comma-separated list)"
         required: true
         type: string
       source_files_translation_mode:
@@ -176,61 +176,23 @@ jobs:
         run: |
           set -euo pipefail
 
-          out=""
+          resolved_files="$(
+            python "${GITHUB_WORKSPACE}/docs-cn/scripts/resolve-ai-docs-source-files.py" \
+              --docs-source-path "${DOCS_SOURCE_PATH}" \
+              --base-ref "${BASE_REF}" \
+              --head-ref "${HEAD_REF}" \
+              --source-folder "${SOURCE_FOLDER}" \
+              --source-toc-file "${SOURCE_TOC_FILE}" \
+              --input-file-names "${INPUT_FILE_NAMES}"
+          )"
 
-          add_file() {
-            local rel="$1"
-            [ -z "${rel}" ] && return
-            case ",${out}," in
-              *",${rel},"*) return ;;
-            esac
-            if [ -z "${out}" ]; then
-              out="${rel}"
-            else
-              out="${out},${rel}"
-            fi
-          }
-
-          normalize_requested_file() {
-            local rel="$1"
-            rel="$(echo "${rel}" | xargs)"
-            rel="${rel#/}"
-            rel="${rel#docs/}"
-
-            if [ -z "${rel}" ]; then
-              return
-            fi
-
-            if [[ "${rel}" == "${SOURCE_TOC_FILE}" || "${rel}" == "${SOURCE_FOLDER}"/* ]]; then
-              add_file "${rel}"
-            else
-              add_file "${SOURCE_FOLDER}/${rel}"
-            fi
-          }
-
-          if [ -n "${INPUT_FILE_NAMES}" ]; then
-            IFS=',' read -ra items <<< "${INPUT_FILE_NAMES}"
-            for item in "${items[@]}"; do
-              normalize_requested_file "${item}"
-            done
-          else
-            readarray -t changed_files < <(
-              git -C "${DOCS_SOURCE_PATH}" diff --name-only -M "${BASE_REF}" "${HEAD_REF}"
-            )
-            for rel in "${changed_files[@]}"; do
-              if [[ "${rel}" == "${SOURCE_TOC_FILE}" || "${rel}" == "${SOURCE_FOLDER}"/* ]]; then
-                add_file "${rel}"
-              fi
-            done
-          fi
-
-          echo "files=${out}" >> "${GITHUB_OUTPUT}"
-          if [ -z "${out}" ]; then
+          echo "files=${resolved_files}" >> "${GITHUB_OUTPUT}"
+          if [ -z "${resolved_files}" ]; then
             echo "has_source_changes=false" >> "${GITHUB_OUTPUT}"
-            echo "No ${SOURCE_FOLDER}/ or ${SOURCE_TOC_FILE} changes detected."
+            echo "No ${SOURCE_FOLDER}/, ${SOURCE_TOC_FILE}, or referenced image changes detected."
           else
             echo "has_source_changes=true" >> "${GITHUB_OUTPUT}"
-            echo "Resolved source files: ${out}"
+            echo "Resolved source files: ${resolved_files}"
           fi
 
       - name: Run commit sync workflow
@@ -329,7 +291,7 @@ jobs:
           body: |
             ### What is changed, added or deleted? (Required)
 
-            Translate `pingcap/docs` AI documentation changes (`${{ env.SOURCE_FOLDER }}/**` and `${{ env.SOURCE_TOC_FILE }}`) to Chinese via `ai-pr-translator` commit-diff sync.
+            Translate `pingcap/docs` AI documentation changes (`${{ env.SOURCE_FOLDER }}/**`, `${{ env.SOURCE_TOC_FILE }}`, and referenced image changes) to Chinese via `ai-pr-translator` commit-diff sync.
 
             English commit diff:
 
@@ -344,7 +306,7 @@ jobs:
             - Source repo: `${{ env.SOURCE_REPO }}`
             - Source branch: `${{ env.SOURCE_BRANCH }}`
             - Terms branch: `${{ env.TERMS_BRANCH }}`
-            - Source paths: `${{ env.SOURCE_FOLDER }}/**`, `${{ env.SOURCE_TOC_FILE }}`
+            - Source paths: `${{ env.SOURCE_FOLDER }}/**`, `${{ env.SOURCE_TOC_FILE }}`, and referenced image changes
             - Source files: `${{ steps.source_files.outputs.files }}`
             - Source files translation mode: `${{ inputs.source_files_translation_mode || 'incremental' }}`
             - Sync outcome: `${{ steps.sync.outcome }}`

--- a/.github/workflows/sync-ai-docs-en-to-zh.yml
+++ b/.github/workflows/sync-ai-docs-en-to-zh.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       file_names:
-        description: "Specify files to translate under docs/ai, TOC-ai.md, or referenced image paths (comma-separated list)"
+        description: "Specify files to translate under docs/ai or TOC-ai.md (comma-separated list)"
         required: true
         type: string
       source_files_translation_mode:

--- a/scripts/resolve-ai-docs-source-files.py
+++ b/scripts/resolve-ai-docs-source-files.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Resolve source files for the AI docs EN-to-ZH sync workflow."""
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import PurePosixPath
+
+
+IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico"}
+MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
+HTML_IMAGE_RE = re.compile(r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']", re.IGNORECASE)
+
+
+def is_image(path):
+    return PurePosixPath(path).suffix.lower() in IMAGE_EXTENSIONS
+
+
+def dedupe(paths):
+    result = []
+    seen = set()
+    for path in paths:
+        if path and path not in seen:
+            result.append(path)
+            seen.add(path)
+    return result
+
+
+def run_git(repo_path, *args):
+    return subprocess.check_output(["git", "-C", repo_path, *args], text=True)
+
+
+def git_show(repo_path, ref, path):
+    try:
+        return subprocess.check_output(
+            ["git", "-C", repo_path, "show", f"{ref}:{path}"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        return ""
+
+
+def list_ai_markdown(repo_path, ref, source_folder):
+    try:
+        output = run_git(repo_path, "ls-tree", "-r", "--name-only", ref, "--", source_folder)
+    except subprocess.CalledProcessError:
+        return []
+    return [path for path in output.splitlines() if path.endswith(".md")]
+
+
+def is_ai_doc_path(path, source_folder, source_toc_file):
+    return path == source_toc_file or path.startswith(f"{source_folder}/")
+
+
+def normalize_image_ref(markdown_path, target):
+    target = target.strip()
+    if not target or target.startswith(("#", "http://", "https://", "mailto:", "data:")):
+        return None
+    if target.startswith("<"):
+        target = target[1:].split(">", 1)[0].strip()
+    else:
+        target = target.split()[0]
+    target = target.split("#", 1)[0].split("?", 1)[0].strip()
+    if not target:
+        return None
+
+    if target.startswith("/"):
+        candidate = target.lstrip("/")
+    else:
+        candidate = str(PurePosixPath(markdown_path).parent.joinpath(target))
+
+    parts = []
+    for part in PurePosixPath(candidate).parts:
+        if part in ("", "."):
+            continue
+        if part == "..":
+            if not parts:
+                return None
+            parts.pop()
+        else:
+            parts.append(part)
+
+    normalized = "/".join(parts)
+    return normalized if normalized and is_image(normalized) else None
+
+
+def referenced_images(repo_path, ref, source_folder):
+    images = set()
+    for markdown_path in list_ai_markdown(repo_path, ref, source_folder):
+        content = git_show(repo_path, ref, markdown_path)
+        for match in MARKDOWN_IMAGE_RE.finditer(content):
+            image_path = normalize_image_ref(markdown_path, match.group(1))
+            if image_path:
+                images.add(image_path)
+        for match in HTML_IMAGE_RE.finditer(content):
+            image_path = normalize_image_ref(markdown_path, match.group(1))
+            if image_path:
+                images.add(image_path)
+    return images
+
+
+def normalize_requested_files(input_file_names, source_folder, source_toc_file):
+    paths = []
+    for item in input_file_names.split(","):
+        path = item.strip().lstrip("/")
+        if path.startswith("./"):
+            path = path[2:]
+        if path.startswith("docs/"):
+            path = path[5:]
+        if not path:
+            continue
+
+        if is_ai_doc_path(path, source_folder, source_toc_file):
+            paths.append(path)
+        elif "/" in path and is_image(path):
+            paths.append(path)
+        else:
+            paths.append(f"{source_folder}/{path}")
+    return dedupe(paths)
+
+
+def resolve_changed_files(repo_path, base_ref, head_ref, source_folder, source_toc_file):
+    changed_files = run_git(repo_path, "diff", "--name-only", "-M", base_ref, head_ref).splitlines()
+    paths = [
+        path
+        for path in changed_files
+        if is_ai_doc_path(path, source_folder, source_toc_file)
+    ]
+
+    changed_images = [path for path in changed_files if is_image(path)]
+    if not changed_images:
+        return dedupe(paths)
+
+    referenced = referenced_images(repo_path, base_ref, source_folder)
+    referenced.update(referenced_images(repo_path, head_ref, source_folder))
+
+    for path in changed_images:
+        if not is_ai_doc_path(path, source_folder, source_toc_file) and path in referenced:
+            paths.append(path)
+            print(f"Including referenced image change: {path}", file=sys.stderr)
+    return dedupe(paths)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--docs-source-path", required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", required=True)
+    parser.add_argument("--source-folder", required=True)
+    parser.add_argument("--source-toc-file", required=True)
+    parser.add_argument("--input-file-names", default="")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    source_folder = args.source_folder.strip("/")
+    if args.input_file_names.strip():
+        paths = normalize_requested_files(
+            args.input_file_names,
+            source_folder,
+            args.source_toc_file,
+        )
+    else:
+        paths = resolve_changed_files(
+            args.docs_source_path,
+            args.base_ref,
+            args.head_ref,
+            source_folder,
+            args.source_toc_file,
+        )
+    print(",".join(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/resolve-ai-docs-source-files.py
+++ b/scripts/resolve-ai-docs-source-files.py
@@ -2,14 +2,20 @@
 """Resolve source files for the AI docs EN-to-ZH sync workflow."""
 
 import argparse
+import io
 import re
 import subprocess
 import sys
+import tarfile
 from pathlib import PurePosixPath
 
 
 IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".svg", ".webp", ".bmp", ".ico"}
+IMAGE_EXTENSION_PATTERN = r"\.(?:png|jpe?g|gif|svg|webp|bmp|ico)"
 MARKDOWN_IMAGE_RE = re.compile(r"!\[[^\]]*\]\(([^)]+)\)")
+MARKDOWN_REFERENCE_IMAGE_RE = re.compile(r"!\[([^\]]+)\]\[([^\]]*)\]")
+MARKDOWN_LINK_DEFINITION_RE = re.compile(r"^ {0,3}\[([^\]]+)\]:\s*(\S.*)$", re.MULTILINE)
+IMAGE_DESTINATION_RE = re.compile(rf"^(.+?{IMAGE_EXTENSION_PATTERN}(?:[?#][^\s\"')>]*)?)", re.IGNORECASE)
 HTML_IMAGE_RE = re.compile(r"<img\b[^>]*\bsrc=[\"']([^\"']+)[\"']", re.IGNORECASE)
 
 
@@ -31,37 +37,53 @@ def run_git(repo_path, *args):
     return subprocess.check_output(["git", "-C", repo_path, *args], text=True)
 
 
-def git_show(repo_path, ref, path):
+def archive_ai_markdown_contents(repo_path, ref, source_folder):
+    """Yield markdown files from source_folder at ref using one git subprocess."""
     try:
-        return subprocess.check_output(
-            ["git", "-C", repo_path, "show", f"{ref}:{path}"],
+        archive_data = subprocess.check_output(
+            ["git", "-C", repo_path, "archive", "--format=tar", ref, source_folder],
             stderr=subprocess.DEVNULL,
-            text=True,
         )
     except subprocess.CalledProcessError:
-        return ""
+        return
 
-
-def list_ai_markdown(repo_path, ref, source_folder):
-    try:
-        output = run_git(repo_path, "ls-tree", "-r", "--name-only", ref, "--", source_folder)
-    except subprocess.CalledProcessError:
-        return []
-    return [path for path in output.splitlines() if path.endswith(".md")]
+    with tarfile.open(fileobj=io.BytesIO(archive_data), mode="r:") as archive:
+        for member in archive.getmembers():
+            if not member.isfile() or not member.name.endswith(".md"):
+                continue
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                continue
+            yield member.name, extracted.read().decode("utf-8", errors="replace")
 
 
 def is_ai_doc_path(path, source_folder, source_toc_file):
     return path == source_toc_file or path.startswith(f"{source_folder}/")
 
 
+def normalize_reference_label(label):
+    return " ".join(label.strip().lower().split())
+
+
+def extract_image_destination(target):
+    target = target.strip()
+    if target.startswith("<"):
+        return target[1:].split(">", 1)[0].strip()
+
+    if is_image(target.split("#", 1)[0].split("?", 1)[0].strip()):
+        return target
+
+    match = IMAGE_DESTINATION_RE.match(target)
+    return match.group(1).strip() if match else target.split()[0]
+
+
 def normalize_image_ref(markdown_path, target):
     target = target.strip()
     if not target or target.startswith(("#", "http://", "https://", "mailto:", "data:")):
         return None
-    if target.startswith("<"):
-        target = target[1:].split(">", 1)[0].strip()
-    else:
-        target = target.split()[0]
+    target = extract_image_destination(target)
+    if not target or target.startswith(("#", "http://", "https://", "mailto:", "data:")):
+        return None
     target = target.split("#", 1)[0].split("?", 1)[0].strip()
     if not target:
         return None
@@ -86,18 +108,36 @@ def normalize_image_ref(markdown_path, target):
     return normalized if normalized and is_image(normalized) else None
 
 
+def images_from_markdown(markdown_path, content):
+    images = set()
+    for match in MARKDOWN_IMAGE_RE.finditer(content):
+        image_path = normalize_image_ref(markdown_path, match.group(1))
+        if image_path:
+            images.add(image_path)
+    for match in HTML_IMAGE_RE.finditer(content):
+        image_path = normalize_image_ref(markdown_path, match.group(1))
+        if image_path:
+            images.add(image_path)
+
+    reference_labels = {
+        normalize_reference_label(match.group(2) or match.group(1))
+        for match in MARKDOWN_REFERENCE_IMAGE_RE.finditer(content)
+    }
+    if reference_labels:
+        for match in MARKDOWN_LINK_DEFINITION_RE.finditer(content):
+            label = normalize_reference_label(match.group(1))
+            if label not in reference_labels:
+                continue
+            image_path = normalize_image_ref(markdown_path, match.group(2))
+            if image_path:
+                images.add(image_path)
+    return images
+
+
 def referenced_images(repo_path, ref, source_folder):
     images = set()
-    for markdown_path in list_ai_markdown(repo_path, ref, source_folder):
-        content = git_show(repo_path, ref, markdown_path)
-        for match in MARKDOWN_IMAGE_RE.finditer(content):
-            image_path = normalize_image_ref(markdown_path, match.group(1))
-            if image_path:
-                images.add(image_path)
-        for match in HTML_IMAGE_RE.finditer(content):
-            image_path = normalize_image_ref(markdown_path, match.group(1))
-            if image_path:
-                images.add(image_path)
+    for markdown_path, content in archive_ai_markdown_contents(repo_path, ref, source_folder):
+        images.update(images_from_markdown(markdown_path, content))
     return images
 
 
@@ -114,7 +154,9 @@ def normalize_requested_files(input_file_names, source_folder, source_toc_file):
 
         if is_ai_doc_path(path, source_folder, source_toc_file):
             paths.append(path)
-        elif "/" in path and is_image(path):
+        elif is_image(path):
+            # Manual image entries are treated as repo-relative paths. Markdown
+            # entries without an explicit folder remain relative to source_folder.
             paths.append(path)
         else:
             paths.append(f"{source_folder}/{path}")
@@ -122,6 +164,9 @@ def normalize_requested_files(input_file_names, source_folder, source_toc_file):
 
 
 def resolve_changed_files(repo_path, base_ref, head_ref, source_folder, source_toc_file):
+    # A failed diff means the workflow cannot safely determine the sync scope, so
+    # let the git error fail the step. Missing source folders at one side of the
+    # range are handled inside archive_ai_markdown_contents() as empty content.
     changed_files = run_git(repo_path, "diff", "--name-only", "-M", base_ref, head_ref).splitlines()
     paths = [
         path

--- a/scripts/tests/test_resolve_ai_docs_source_files.py
+++ b/scripts/tests/test_resolve_ai_docs_source_files.py
@@ -1,0 +1,87 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "resolve-ai-docs-source-files.py"
+SPEC = importlib.util.spec_from_file_location("resolve_ai_docs_source_files", SCRIPT_PATH)
+resolver = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(resolver)
+
+
+class ResolveAiDocsSourceFilesTest(unittest.TestCase):
+    def test_normalize_image_ref_resolves_deep_relative_path(self):
+        self.assertEqual(
+            resolver.normalize_image_ref(
+                "ai/integrations/vector-search/doc.md",
+                "../../media/image.png",
+            ),
+            "ai/media/image.png",
+        )
+
+    def test_normalize_image_ref_resolves_absolute_repo_path(self):
+        self.assertEqual(
+            resolver.normalize_image_ref("ai/doc.md", "/media/foo.png"),
+            "media/foo.png",
+        )
+
+    def test_normalize_image_ref_strips_query_and_fragment(self):
+        self.assertEqual(
+            resolver.normalize_image_ref("ai/doc.md", "images/foo.png?v=2#section"),
+            "ai/images/foo.png",
+        )
+
+    def test_normalize_image_ref_handles_angle_brackets(self):
+        self.assertEqual(
+            resolver.normalize_image_ref("ai/doc.md", "<../media/foo.png>"),
+            "media/foo.png",
+        )
+
+    def test_normalize_image_ref_handles_spaces_in_path(self):
+        self.assertEqual(
+            resolver.normalize_image_ref("ai/doc.md", "images/path with spaces/image.png"),
+            "ai/images/path with spaces/image.png",
+        )
+
+    def test_normalize_image_ref_handles_optional_title(self):
+        self.assertEqual(
+            resolver.normalize_image_ref("ai/doc.md", 'images/foo.png "title"'),
+            "ai/images/foo.png",
+        )
+
+    def test_normalize_image_ref_ignores_external_images(self):
+        self.assertIsNone(
+            resolver.normalize_image_ref("ai/doc.md", "<https://example.com/foo.png>")
+        )
+
+    def test_images_from_markdown_finds_reference_style_images(self):
+        content = """
+![Inline](./inline.png)
+![Reference image][diagram]
+![Collapsed reference][]
+
+[diagram]: ../media/diagram.svg "Diagram"
+[Collapsed reference]: /media/collapsed.webp
+"""
+        self.assertEqual(
+            resolver.images_from_markdown("ai/guide/doc.md", content),
+            {
+                "ai/guide/inline.png",
+                "ai/media/diagram.svg",
+                "media/collapsed.webp",
+            },
+        )
+
+    def test_normalize_requested_files_treats_images_as_repo_relative(self):
+        self.assertEqual(
+            resolver.normalize_requested_files(
+                "media/diagram.png, vector-search.md, overview.png",
+                "ai",
+                "TOC-ai.md",
+            ),
+            ["media/diagram.png", "ai/vector-search.md", "overview.png"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the AI docs EN-to-ZH sync workflow to include changed image files that are referenced by `ai/**/*.md`, even when those images are outside the `ai/` directory.

This PR also moves the source-file resolution logic into `scripts/resolve-ai-docs-source-files.py` so the workflow stays small and the image-reference logic is easier to test.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)
- [ ] v6.1 (TiDB 6.1 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/docs-cn/pull/21788

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch
