### PR TITLE
chore: rename AI Markdown translator references

### DIFF
--- a/.github/workflows/sync-ai-docs-en-to-zh.yml
+++ b/.github/workflows/sync-ai-docs-en-to-zh.yml
@@ -45,7 +45,7 @@ env:
   SOURCE_REPO: pingcap/docs
   SOURCE_BRANCH: release-8.5
   TERMS_BRANCH: master
-  AI_TRANSLATOR_REPO: qiancai/ai-pr-translator
+  AI_TRANSLATOR_REPO: qiancai/ai-markdown-translator
   AI_TRANSLATOR_REF: main
   SOURCE_FOLDER: ai
   SOURCE_TOC_FILE: TOC-ai.md
@@ -125,11 +125,11 @@ jobs:
           persist-credentials: false
 
       - uses: actions/checkout@v6
-        name: Checkout ai-pr-translator
+        name: Checkout ai-markdown-translator
         with:
           repository: ${{ env.AI_TRANSLATOR_REPO }}
           ref: ${{ env.AI_TRANSLATOR_REF }}
-          path: ai-pr-translator
+          path: ai-markdown-translator
           persist-credentials: false
 
       - uses: actions/setup-python@v6
@@ -137,14 +137,14 @@ jobs:
         with:
           python-version: "3.9"
           cache: pip
-          cache-dependency-path: ai-pr-translator/scripts/requirements.txt
+          cache-dependency-path: ai-markdown-translator/scripts/requirements.txt
 
       - name: Install dependencies
         shell: bash
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
-          pip install -r ai-pr-translator/scripts/requirements.txt
+          pip install -r ai-markdown-translator/scripts/requirements.txt
 
       - name: Resolve commit range
         id: commits
@@ -277,7 +277,7 @@ jobs:
           SKIP_TRANSLATING_AI_DOCS_TO_ZH: "false"
         run: |
           set -euo pipefail
-          cd ai-pr-translator/scripts
+          cd ai-markdown-translator/scripts
           python commit_sync_workflow.py
 
       - name: Prepare translated changes
@@ -287,7 +287,7 @@ jobs:
         working-directory: docs-cn
         env:
           HEAD_REF: ${{ steps.commits.outputs.head_ref }}
-          FAILURE_REPORT: ${{ github.workspace }}/ai-pr-translator/scripts/temp_output/translation-failures.md
+          FAILURE_REPORT: ${{ github.workspace }}/ai-markdown-translator/scripts/temp_output/translation-failures.md
         run: |
           set -euo pipefail
 
@@ -339,7 +339,7 @@ jobs:
           body: |
             ### What is changed, added or deleted? (Required)
 
-            Translate `pingcap/docs` AI documentation changes (`${{ env.SOURCE_FOLDER }}/**`, `${{ env.SOURCE_TOC_FILE }}`, and referenced image changes) to Chinese via `ai-pr-translator` commit-diff sync.
+            Translate `pingcap/docs` AI documentation changes (`${{ env.SOURCE_FOLDER }}/**`, `${{ env.SOURCE_TOC_FILE }}`, and referenced image changes) to Chinese via `ai-markdown-translator` commit-diff sync.
 
             English commit diff:
 

--- a/.github/workflows/sync-doc-pr-en-to-zh.yml
+++ b/.github/workflows/sync-doc-pr-en-to-zh.yml
@@ -40,12 +40,12 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Checkout ai-pr-translator repository
+      - name: Checkout ai-markdown-translator repository
         uses: actions/checkout@v6
         with:
-          repository: "qiancai/ai-pr-translator"
+          repository: "qiancai/ai-markdown-translator"
           ref: "main"
-          path: "ai-pr-translator"
+          path: "ai-markdown-translator"
           persist-credentials: false
 
       - name: Checkout docs repository glossary
@@ -63,7 +63,7 @@ jobs:
           python-version: '3.9'
 
       - name: Install dependencies
-        run: pip install -r ai-pr-translator/scripts/requirements.txt
+        run: pip install -r ai-markdown-translator/scripts/requirements.txt
 
       - name: Extract PR information
         id: extract_info
@@ -194,7 +194,7 @@ jobs:
           TARGET_REPO_PATH: ${{ github.workspace }}/target_repo
           TERMS_PATH: ${{ github.workspace }}/docs-master/resources/terms.md
         run: |
-          cd ai-pr-translator/scripts
+          cd ai-markdown-translator/scripts
           if python main_workflow.py; then
             echo "sync_success=true" >> $GITHUB_OUTPUT
             echo "✅ Sync script completed successfully"


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

Update the GitHub Actions workflows to use the renamed `qiancai/ai-markdown-translator` repository and matching checkout paths.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from:
- Other reference link(s): https://github.com/qiancai/ai-markdown-translator

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 更新文档同步与翻译流程，改用新的 Markdown 翻译工具，提升中英文文档自动同步的稳定性。
  * 翻译失败汇总及自动创建的更新说明将适配新的翻译流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->