### PR TITLE
tiup: document Prometheus external labels in Chinese

### DIFF
--- a/tiup/customized-montior-in-tiup-environment.md
+++ b/tiup/customized-montior-in-tiup-environment.md
@@ -72,6 +72,28 @@ monitoring_servers:
 
 上述配置后，在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 additional_scrape_conf 字段的内容会添加到 Prometheus 配置文件的对应参数中。
 
+### 自定义 Prometheus external labels
+
+从 TiUP v1.17.0 开始，你可以在拓扑文件中配置 Prometheus 全局 `external_labels`。
+
+1. 打开 TiDB 集群的拓扑配置文件 topology.yaml。
+
+2. 在 monitoring_servers 的配置部分添加 `external_labels` 字段。
+
+    以下为 topology.yaml 文件中的 monitoring_servers 配置示例：
+
+    ```yaml
+    monitoring_servers:
+    - host: xxxxxxx
+      external_labels:
+        environment: production
+        region: us-east-1
+    ```
+
+3. 不要配置保留 label `cluster` 和 `monitor`，也不要使用以 `__` 开头的 label 名；所有 label 名都必须符合 Prometheus label name 规则。
+
+上述配置后，在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 `external_labels` 字段渲染到 Prometheus 全局 `external_labels` 配置中。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败。
+
 ## 自定义 Grafana 配置
 
 目前，TiUP 支持自定义 Grafana Dashboard 和其他配置。

--- a/tiup/customized-montior-in-tiup-environment.md
+++ b/tiup/customized-montior-in-tiup-environment.md
@@ -72,15 +72,15 @@ monitoring_servers:
 
 上述配置后，在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 additional_scrape_conf 字段的内容会添加到 Prometheus 配置文件的对应参数中。
 
-### 自定义 Prometheus external labels
+### 自定义 Prometheus 外部标签
 
 从 TiUP v1.17.0 开始，你可以在拓扑文件中配置 Prometheus 全局 `external_labels`。
 
-1. 打开 TiDB 集群的拓扑配置文件 topology.yaml。
+1. 打开 TiDB 集群的拓扑配置文件 `topology.yaml`。
 
-2. 在 monitoring_servers 的配置部分添加 `external_labels` 字段。
+2. 在 `monitoring_servers` 的配置部分添加 `external_labels` 字段。
 
-    以下为 topology.yaml 文件中的 monitoring_servers 配置示例：
+    以下为 `topology.yaml` 文件中的 `monitoring_servers` 配置示例：
 
     ```yaml
     monitoring_servers:
@@ -90,9 +90,11 @@ monitoring_servers:
         region: us-east-1
     ```
 
-3. 不要配置保留 label `cluster` 和 `monitor`，也不要使用以 `__` 开头的 label 名；所有 label 名都必须符合 Prometheus label name 规则。
+3. 不要配置保留 label `cluster` 和 `monitor`，也不要使用以 `__` 开头的 label 名；所有 label 名都必须符合 Prometheus 标签命名规则。
 
-上述配置后，在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 `external_labels` 字段渲染到 Prometheus 全局 `external_labels` 配置中。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败。
+完成上述配置后，当你部署、扩容、缩容或重载 TiDB 集群时，TiUP 会将 `external_labels` 字段渲染到 Prometheus 全局 `external_labels` 配置中。
+
+如果使用不支持该字段的早期版本 TiUP 打开拓扑配置文件，TiUP 不会忽略该字段，而是会解析拓扑配置失败。
 
 ## 自定义 Grafana 配置
 

--- a/tiup/tiup-cluster-topology-reference.md
+++ b/tiup/tiup-cluster-topology-reference.md
@@ -535,6 +535,7 @@ scheduling_servers:
 - `arch`：`host` 字段所指定的机器的架构，若不指定该字段，则默认为 `global` 中的 `arch`
 - `resource_control`：针对该服务的资源控制，如果配置了该字段，会将该字段和 `global` 中的 `resource_control` 内容合并（若字段重叠，以本字段内容为准），然后生成 systemd 配置文件并下发到 `host` 指定机器。`resource_control` 的配置规则同 `global` 中的 `resource_control`
 - `additional_args`：从 TiUP v1.15.0 开始引入，用于配置 Prometheus 额外运行参数。该字段是一个数组，数组元素为 Prometheus 运行参数。例如，要开启 Prometheus 热加载功能，可以将该字段配置为 `--web.enable-lifecycle`
+- `external_labels`：从 TiUP v1.17.0 开始引入，用于为 Prometheus 配置全局 `external_labels`，字段值为 key/value 对。可用于为 Prometheus `remote_write`、联邦抓取和告警附加稳定元数据。TiUP 会自动管理 `cluster` 和 `monitor` 这两个保留 label，因此不要在该字段中配置它们。以 `__` 开头的 label 名同样保留不可用，且所有 label 名都必须符合 Prometheus label name 规则。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败
 - `additional_scrape_conf`：自定义 Prometheus scrape 配置。在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 `additional_scrape_conf` 字段的内容添加到 Prometheus 配置文件的对应参数中。更多信息，请参考[自定义监控组件的配置](/tiup/customized-montior-in-tiup-environment.md#自定义-prometheus-scrape-配置)
 
 以上所有字段中，部分字段部署完成之后不能再修改。如下所示：
@@ -555,6 +556,9 @@ monitoring_servers:
     rule_dir: /local/rule/dir
     additional_args:
     - --web.enable-lifecycle
+    external_labels:
+      environment: production
+      region: us-east-1
     remote_config:
       remote_write:
       - queue_config:

--- a/tiup/tiup-cluster-topology-reference.md
+++ b/tiup/tiup-cluster-topology-reference.md
@@ -535,7 +535,7 @@ scheduling_servers:
 - `arch`：`host` 字段所指定的机器的架构，若不指定该字段，则默认为 `global` 中的 `arch`
 - `resource_control`：针对该服务的资源控制，如果配置了该字段，会将该字段和 `global` 中的 `resource_control` 内容合并（若字段重叠，以本字段内容为准），然后生成 systemd 配置文件并下发到 `host` 指定机器。`resource_control` 的配置规则同 `global` 中的 `resource_control`
 - `additional_args`：从 TiUP v1.15.0 开始引入，用于配置 Prometheus 额外运行参数。该字段是一个数组，数组元素为 Prometheus 运行参数。例如，要开启 Prometheus 热加载功能，可以将该字段配置为 `--web.enable-lifecycle`
-- `external_labels`：从 TiUP v1.17.0 开始引入，用于为 Prometheus 配置全局 `external_labels`，字段值为 key/value 对。可用于为 Prometheus `remote_write`、联邦抓取和告警附加稳定元数据。TiUP 会自动管理 `cluster` 和 `monitor` 这两个保留 label，因此不要在该字段中配置它们。以 `__` 开头的 label 名同样保留不可用，且所有 label 名都必须符合 Prometheus label name 规则。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败
+- `external_labels`：从 TiUP v1.17.0 开始引入，该字段用于以键值对的形式配置 Prometheus 全局 `external_labels`。你可以使用该字段为 Prometheus 的 `remote_write`、联邦抓取 (federation) 和告警附加稳定元数据。TiUP 会自动管理并保留 `cluster` 和 `monitor` 标签，因此不要在该字段中配置这些标签。此外，以 `__` 开头的标签名称同样是保留的，所有标签名称都必须符合 Prometheus 标签命名规则。如果使用不支持该字段的早期版本 TiUP 读取拓扑配置文件，TiUP 不会忽略该字段，而是直接解析失败。
 - `additional_scrape_conf`：自定义 Prometheus scrape 配置。在集群进行 deploy/scale-out/scale-in/reload 操作时，TiUP 会将 `additional_scrape_conf` 字段的内容添加到 Prometheus 配置文件的对应参数中。更多信息，请参考[自定义监控组件的配置](/tiup/customized-montior-in-tiup-environment.md#自定义-prometheus-scrape-配置)
 
 以上所有字段中，部分字段部署完成之后不能再修改。如下所示：

--- a/tiup/tiup-dm-topology-reference.md
+++ b/tiup/tiup-dm-topology-reference.md
@@ -199,6 +199,7 @@ worker_servers:
     - `remote_write`：参考 Prometheus [`<remote_write>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) 文档
     - `remote_read`：参考 Prometheus [`<remote_read>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read) 文档
 - `external_alertmanagers`：若配置了 `external_alertmanagers`，Prometheus 会将配置行为报警通知到集群外的 Alertmanager。该字段为一个数组，数组的元素为每个外部的 Alertmanager，由 `host` 和 `web_port` 字段构成
+- `external_labels`：从 TiUP v1.17.0 开始引入，用于为 Prometheus 配置全局 `external_labels`，字段值为 key/value 对。可用于为 Prometheus `remote_write`、联邦抓取和告警附加稳定元数据。TiUP 会自动管理 `cluster` 和 `monitor` 这两个保留 label，因此不要在该字段中配置它们。以 `__` 开头的 label 名同样保留不可用，且所有 label 名都必须符合 Prometheus label name 规则。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败
 - `os`：`host` 字段所指定的机器的操作系统，若不指定该字段，则默认为 `global` 中的 `os`
 - `arch`：`host` 字段所指定的机器的架构，若不指定该字段，则默认为 `global` 中的 `arch`
 - `resource_control`：针对该服务的资源控制，如果配置了该字段，会将该字段和 `global` 中的 `resource_control` 内容合并（若字段重叠，以本字段内容为准），然后生成 systemd 配置文件并下发到 `host` 指定机器。`resource_control` 的配置规则同 `global` 中的 `resource_control`
@@ -219,6 +220,9 @@ worker_servers:
 monitoring_servers:
   - host: 10.0.1.11
     rule_dir: /local/rule/dir
+    external_labels:
+      environment: production
+      region: us-east-1
     remote_config:
       remote_write:
       - queue_config:

--- a/tiup/tiup-dm-topology-reference.md
+++ b/tiup/tiup-dm-topology-reference.md
@@ -199,7 +199,7 @@ worker_servers:
     - `remote_write`：参考 Prometheus [`<remote_write>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) 文档
     - `remote_read`：参考 Prometheus [`<remote_read>`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_read) 文档
 - `external_alertmanagers`：若配置了 `external_alertmanagers`，Prometheus 会将配置行为报警通知到集群外的 Alertmanager。该字段为一个数组，数组的元素为每个外部的 Alertmanager，由 `host` 和 `web_port` 字段构成
-- `external_labels`：从 TiUP v1.17.0 开始引入，用于为 Prometheus 配置全局 `external_labels`，字段值为 key/value 对。可用于为 Prometheus `remote_write`、联邦抓取和告警附加稳定元数据。TiUP 会自动管理 `cluster` 和 `monitor` 这两个保留 label，因此不要在该字段中配置它们。以 `__` 开头的 label 名同样保留不可用，且所有 label 名都必须符合 Prometheus label name 规则。若使用不支持该字段的旧版 TiUP 打开包含该字段的拓扑文件，不会忽略未知字段，而是直接解析失败
+- `external_labels`：从 TiUP v1.17.0 开始引入，该字段用于以键值对的形式配置 Prometheus 全局 `external_labels`。你可以使用该字段为 Prometheus 的 `remote_write`、联邦抓取 (federation) 和告警附加稳定元数据。TiUP 会自动管理并保留 `cluster` 和 `monitor` 标签，因此不要在该字段中配置这些标签。此外，以 `__` 开头的标签名称同样是保留的，所有标签名称都必须符合 Prometheus 标签命名规则。如果使用不支持该字段的早期版本 TiUP 读取拓扑配置文件，TiUP 不会忽略该字段，而是直接解析失败。
 - `os`：`host` 字段所指定的机器的操作系统，若不指定该字段，则默认为 `global` 中的 `os`
 - `arch`：`host` 字段所指定的机器的架构，若不指定该字段，则默认为 `global` 中的 `arch`
 - `resource_control`：针对该服务的资源控制，如果配置了该字段，会将该字段和 `global` 中的 `resource_control` 内容合并（若字段重叠，以本字段内容为准），然后生成 systemd 配置文件并下发到 `host` 指定机器。`resource_control` 的配置规则同 `global` 中的 `resource_control`


### PR DESCRIPTION
### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [ ] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

This PR adds the Chinese documentation for TiUP support for `monitoring_servers[].external_labels`.

It mirrors the English docs update by documenting the new field in the TiUP cluster and DM topology references, and by adding a dedicated section to the monitoring customization guide. It also keeps the compatibility note aligned with the implementation: older TiUP versions fail to parse the topology file instead of ignoring the field.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/23358
- Other reference link(s):
  - https://github.com/pingcap/tiup/issues/1795
  - https://github.com/pingcap/tiup/pull/2719
  - https://github.com/pingcap/tiup/releases#release-v1.17.0

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 新增 Prometheus 自定义外部标签（`external_labels`）配置说明。
  * 补充 `environment`、`region` 等配置示例。
  * 说明标签命名限制及 `cluster`、`monitor` 保留标签约束。
  * 明确该配置需 TiUP v1.17.0 及以上版本支持，旧版本解析时可能失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->