### PR TITLE
Document IMPORT INTO restriction for TTL-enabled tables

### DIFF
--- a/sql-statements/sql-statement-import-into.md
+++ b/sql-statements/sql-statement-import-into.md
@@ -18,7 +18,7 @@ summary: TiDB 数据库中 IMPORT INTO 的使用概况。
 
 - 只支持导入数据到数据库中已有的空表。
 - 如果表中其他分区已包含数据，不支持将数据导入到该表的空分区中。目标表必须完全为空才能执行导入操作。
-- 不支持导入到[临时表](/temporary-tables.md)或者[缓存表](/cached-tables.md)。
+- 不支持导入到[临时表](/temporary-tables.md)或者[缓存表](/cached-tables.md)或者启用了 TTL 的表。
 - 不支持事务，也无法回滚。在显式事务 (`BEGIN`/`END`) 中执行会报错。
 - 不支持和 [Backup & Restore](/br/backup-and-restore-overview.md)、[`FLASHBACK CLUSTER`](/sql-statements/sql-statement-flashback-cluster.md)、[创建索引加速](/system-variables.md#tidb_ddl_enable_fast_reorg-从-v630-版本开始引入)、TiDB Lightning 导入、TiCDC 数据同步、[Point-in-time recovery (PITR)](/br/br-log-architecture.md) 等功能同时工作。相关兼容性介绍，请参见 [`IMPORT INTO` 和 TiDB Lightning 与日志备份和 TiCDC 的兼容性](/tidb-lightning/tidb-lightning-compatibility-and-scenarios.md)。
 - 导入数据的过程中，请勿在目标表上执行 DDL 和 DML 操作，也不要在目标数据库上执行 [`FLASHBACK DATABASE`](/sql-statements/sql-statement-flashback-database.md)，否则会导致导入失败或数据不一致。导入期间也不建议进行读操作，因为读取的数据可能不一致。请在导入完成后再进行读写操作。


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Document that `IMPORT INTO` does not support importing data into a table with TTL enabled.

The restrictions list already covered temporary and cached tables but omitted TTL-enabled tables. As described in pingcap/tidb#70426, an asynchronous TTL job can delete rows while an import is running, which can cause the final checksum verification to fail. This update closes that documentation gap so users can avoid running `IMPORT INTO` against an unsupported target table.

Validation: `./scripts/markdownlint sql-statements/sql-statement-import-into.md` and `git diff --check`.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions](https://github.com/pingcap/docs/blob/master/CONTRIBUTING.md#guideline-for-choosing-the-affected-versions).

- [x] master (the latest development version)
- [x] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/23507
- Other reference link(s):
  - Issue: https://github.com/pingcap/tidb/issues/70426
  - PR: https://github.com/pingcap/tidb/pull/70427

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **文档**
  * 更新 `IMPORT INTO` 使用限制：不支持将数据导入启用 TTL 的表。
  * 保持临时表和缓存表的现有限制不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->