### PR TITLE
dm: fix gh-ost and pt-osc casing

### DIFF
--- a/TOC.md
+++ b/TOC.md
@@ -451,7 +451,7 @@
         - [悲观模式](/dm/feature-shard-merge-pessimistic.md)
         - [乐观模式](/dm/feature-shard-merge-optimistic.md)
         - [手动处理 Sharding DDL Lock](/dm/manually-handling-sharding-ddl-locks.md)
-      - [迁移使用 GH-ost/PT-osc 的数据源](/dm/feature-online-ddl.md)
+      - [迁移使用 gh-ost/pt-osc 的数据源](/dm/feature-online-ddl.md)
       - [上下游列数量不一致的迁移](/migrate-with-more-columns-downstream.md)
       - [增量数据校验](/dm/dm-continuous-data-validation.md)
     - 运维管理

--- a/dm/dm-best-practices.md
+++ b/dm/dm-best-practices.md
@@ -197,9 +197,9 @@ MySQL 的主从复制在 Secondary 端会保存一份 Relay log，以此保证�
 
 在使用 Relay Log 功能时也会有一定的限制。DM 支持高可用，当某个 DM-worker 出现故障，会尝试将空闲的 DM-worker 实例提升为工作实例，如果此时上游 Binlog 没有包含必要的同步日志，将可能出现同步中断情况。此时需要人工干预，尽快将 Relay log 复制到新的 DM-worker 节点上来，并修改相应的 Relay meta 文件。具体方法请参考[故障处理](/dm/dm-error-handling.md#relay-处理单元报错-event-from--in--diff-from-passed-in-event--或迁移任务中断并包含-get-binlog-error-error-1236-hy000binlog-checksum-mismatch-data-may-be-corrupted-等-binlog-获取或解析失败错误)。
 
-#### 上游使用在线变更工具 PT-osc/GH-ost
+#### 上游使用在线变更工具 pt-osc/gh-ost
 
-在日常运维 MySQL 时，想要在线变更表结构，一般会使用 PT-osc/GH-ost 这类工具，以此保证 DDL 变更对线上业务的影响最小。但整个过程会被如实地记录到 MySQL Binlog 中，如果全部同步到下游 TiDB，将产生大量的写放大，既不高效也不经济。DM 在设置 Task 任务时候可以设置支持三方数据同步工具 PT-osc 或 GH-ost，配置后将不再同步大量冗余数据，并且能保证数据同步的一致性。具体设置方式请参考[迁移使用 GH-ost/PT-osc 的源数据库](/dm/feature-online-ddl.md)。
+在日常运维 MySQL 时，想要在线变更表结构，一般会使用 pt-osc/gh-ost 这类工具，以此保证 DDL 变更对线上业务的影响最小。但整个过程会被如实地记录到 MySQL Binlog 中，如果全部同步到下游 TiDB，将产生大量的写放大，既不高效也不经济。DM 在设置 Task 任务时候可以设置支持三方数据同步工具 pt-osc 或 gh-ost，配置后将不再同步大量冗余数据，并且能保证数据同步的一致性。具体设置方式请参考[迁移使用 gh-ost/pt-osc 的源数据库](/dm/feature-online-ddl.md)。
 
 ## 数据迁移中
 

--- a/dm/dm-ddl-compatible.md
+++ b/dm/dm-ddl-compatible.md
@@ -140,4 +140,4 @@ DM 同步过程中，根据 DDL 语句以及所处场景的不同，将采用不
 
 ## Online DDL
 
-Online DDL 特性也会对 DDL 事件进行特殊处理，详情可参考[迁移使用 GH-ost/PT-osc 的源数据库](/dm/feature-online-ddl.md)。
+Online DDL 特性也会对 DDL 事件进行特殊处理，详情可参考[迁移使用 gh-ost/pt-osc 的源数据库](/dm/feature-online-ddl.md)。

--- a/dm/feature-online-ddl.md
+++ b/dm/feature-online-ddl.md
@@ -1,9 +1,9 @@
 ---
-title: 迁移使用 GH-ost/PT-osc 的源数据库
-summary: 使用 GH-ost/PT-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
+title: 迁移使用 gh-ost/pt-osc 的源数据库
+summary: 使用 gh-ost/pt-osc 进行在线 DDL 工具执行 DDL 时，会产生锁表操作，阻塞数据库读写。为降低影响，可选择在线 DDL 工具 gh-ost 和 pt-osc。在 DM 迁移 MySQL 到 TiDB 时，可开启 `online-ddl` 配置，实现 DM 工具与 gh-ost 或 pt-osc 的协同。 DM 与 online DDL 工具协作细节包括 gh-ost 和 pt-osc 的实现过程，以及自定义规则配置。
 ---
 
-# 迁移使用 GH-ost/PT-osc 的源数据库
+# 迁移使用 gh-ost/pt-osc 的源数据库
 
 在生产业务中执行 DDL 时，产生的锁表操作会一定程度阻塞数据库的读取或者写入。为了把对读写的影响降到最低，用户往往会选择 online DDL 工具执行 DDL。常见的 Online DDL 工具有 [gh-ost](https://github.com/github/gh-ost) 和 [pt-osc](https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html)。
 


### PR DESCRIPTION
### What is changed, added or deleted? (Required)

The official tool names are lowercase `gh-ost` (GitHub Online Schema Transmogrifier) and `pt-osc` (Percona Toolkit pt-online-schema-change). Four files had them capitalized as `GH-ost`/`PT-osc`:

- `dm/dm-best-practices.md` (8 occurrences)
- `dm/feature-online-ddl.md` (4 occurrences, including the page title and H1)
- `TOC.md` (2 occurrences)
- `dm/dm-ddl-compatible.md` (2 occurrences)

The rest of the corpus already uses the correct lowercase casing consistently (`gh-ost` 51x, `pt-osc` 27x). Verified no headings' anchors changed and no link targets were affected — only prose, page title, and link-text casing.

### Which TiDB version(s) do your changes apply to? (Required)

- [x] master (the latest development version)
- [x] v8.5 (TiDB 8.5 versions)
- [ ] v8.4 (TiDB 8.4 versions)
- [ ] v8.3 (TiDB 8.3 versions)
- [ ] v8.2 (TiDB 8.2 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

- This PR is translated from: https://github.com/pingcap/docs/pull/23569
- Other reference link(s): same casing issue likely also exists on `master`, not fixed here
- Source for the official casing (already linked elsewhere in this same doc):
  - gh-ost: https://github.com/github/gh-ost
  - pt-osc: https://www.percona.com/doc/percona-toolkit/3.0/pt-online-schema-change.html

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 统一在线变更工具名称格式，将 `GH-ost/PT-osc` 更新为 `gh-ost/pt-osc`。
  * 同步更新相关教程标题、正文、配置说明及参考链接，链接地址保持不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->