### PR TITLE
ticdc: document transaction start TSO in Debezium and Simple

### DIFF
--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -347,6 +347,14 @@ Info: {"upstream_id":7178706266519722477,"namespace":"default","id":"simple-repl
 - 是否输出行数据更改前的值。关闭后，UPDATE 事件不会输出 "before" 字段的数据。
 - 默认值：`true`
 
+##### `include-start-ts` <span class="version-mark">从 v8.5.9 版本开始引入</span>
+
+- 控制 Debezium JSON DML 消息是否包含 `source.start_ts`（源事务的原始 PD TSO）。
+- 默认值：`false`
+- 该参数只有当 sink 类型为 MQ 且输出协议为 Debezium JSON 时才生效。与 Debezium Avro 一起设置会被拒绝。
+- 你也可以设置等价的 URI 参数 `debezium-include-start-ts`。显式指定的 URI 参数优先于该配置项，包括使用 `false` 覆盖 `true`。
+- 关于消息格式和消费者精度要求，请参考 [TiCDC Debezium Protocol](/ticdc/ticdc-debezium.md#包含事务开始-tso)。
+
 ### consistent
 
 consistent 中的字段用于配置 Changefeed 的数据一致性。详细信息请参考[灾难场景的最终一致性复制](/ticdc/ticdc-sink-to-mysql.md#灾难场景的最终一致性复制)。

--- a/ticdc/ticdc-changefeed-config.md
+++ b/ticdc/ticdc-changefeed-config.md
@@ -347,13 +347,23 @@ Info: {"upstream_id":7178706266519722477,"namespace":"default","id":"simple-repl
 - 是否输出行数据更改前的值。关闭后，UPDATE 事件不会输出 "before" 字段的数据。
 - 默认值：`true`
 
-##### `include-start-ts` <span class="version-mark">从 v8.5.9 版本开始引入</span>
+##### `include-start-ts`
 
 - 控制 Debezium JSON DML 消息是否包含 `source.start_ts`（源事务的原始 PD TSO）。
 - 默认值：`false`
-- 该参数只有当 sink 类型为 MQ 且输出协议为 Debezium JSON 时才生效。与 Debezium Avro 一起设置会被拒绝。
-- 你也可以设置等价的 URI 参数 `debezium-include-start-ts`。显式指定的 URI 参数优先于该配置项，包括使用 `false` 覆盖 `true`。
+- 需要使用 [TiCDC 新架构](/ticdc/ticdc-architecture.md)。该参数仅对 `protocol = "debezium"` 的 MQ sink 生效。在其他协议（包括 `debezium-avro`）中开启该选项会被拒绝。
+- 你也可以设置等价的 URI 参数 `debezium-include-start-ts`。显式指定的 URI 参数优先于该配置项，包括使用 `debezium-include-start-ts=false` 覆盖 `[sink.debezium] include-start-ts = true`。
 - 关于消息格式和消费者精度要求，请参考 [TiCDC Debezium Protocol](/ticdc/ticdc-debezium.md#包含事务开始-tso)。
+
+#### sink.simple
+
+##### `include-start-ts`
+
+- 控制 Simple JSON DML 消息是否包含顶层字段 `startTs`（源事务的原始 PD TSO）。
+- 默认值：`false`
+- 需要使用 [TiCDC 新架构](/ticdc/ticdc-architecture.md)。该参数仅对使用 `protocol = "simple"` 和 JSON 编码的 MQ sink 生效。在其他协议或 `encoding-format = "avro"` 下开启该选项会被拒绝。
+- 显式指定的 URI 参数 `simple-include-start-ts` 优先于该配置项，包括使用 `simple-include-start-ts=false` 覆盖 `[sink.simple] include-start-ts = true`。
+- 配置示例和整数精度要求详见 [TiCDC Simple Protocol](/ticdc/ticdc-simple-protocol.md#包含事务开始-tso)。
 
 ### consistent
 

--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -27,6 +27,47 @@ Debezium 输出格式中包含当前行的 Schema 信息，以便下游消费者
 
 此外，Debezium 原有格式中并不包含 TiDB 专有的 `CommitTS` 事务唯一标识等重要字段。为了保证数据的完整性，TiCDC 在 Debezium 格式中增加了 `CommitTs` 和 `ClusterID` 两个字段，用于标识 TiDB 数据变更的相关信息。
 
+### 包含事务开始 TSO <span class="version-mark">从 v8.5.9 版本开始引入</span>
+
+默认情况下，Debezium JSON DML 消息包含 `source.commit_ts`，但不包含事务开始 TSO。你可以选择仅在 DML 行事件中包含 `source.start_ts`（源事务开始时的原始 PD TSO）。该选项默认关闭。
+
+你可以通过以下任一方式开启该选项：
+
+- 在 `sink-uri` 中：
+
+    ```
+    kafka://127.0.0.1:9092/topic-name?protocol=debezium&debezium-include-start-ts=true
+    ```
+
+- 在 changefeed 配置文件中：
+
+    ```toml
+    [sink.debezium]
+    include-start-ts = true
+    ```
+
+显式指定的 URI 参数优先于配置文件，包括使用 `debezium-include-start-ts=false` 覆盖 `include-start-ts = true`。
+
+开启该选项后：
+
+- DML 消息的 value 会在 `commit_ts` 旁增加整型字段 `source.start_ts`，JSON schema 将该字段声明为 `int64`。
+- DDL 事件、WATERMARK 事件、key 消息和 Debezium Avro 不受影响。将该选项与 Debezium Avro 协议一起使用会被拒绝。
+- 如需回滚，关闭该选项即可。关闭期间产出的消息与此前格式保持兼容。
+
+> **注意：**
+>
+> `start_ts` 是原始的 uint64 PD TSO，不是毫秒时间戳。消费者必须将其作为 64 位整数或十进制字符串处理。不要将其解析为 JavaScript `Number` 或 IEEE-754 `float64`，后者无法精确表示 18 位 TSO。
+
+开启该选项后，`source` 字段类似如下：
+
+```json
+"source": {
+    "commit_ts": 447507027004751877,
+    "start_ts": 447507027004751800,
+    "cluster_id": "default"
+}
+```
+
 ## 消息格式定义
 
 本节介绍 DDL 事件、DML 事件和 WATERMARK 事件的消息格式。
@@ -570,6 +611,7 @@ Key 中的字段只包含主键或唯一索引列。字段解释如下：
 | `payload.before`    | JSON   | 这条事件语句变更前的数据值。对于 `"c"` 事件，`before` 字段的值为 `null`。  |
 | `payload.after`     | JSON   | 这条事件语句变更后的数据值。对于 `"d"` 事件，`after` 字段的值为 `null`。   |
 | `payload.source.commit_ts`     | 数值  | 该事件的 `CommitTs` 值。                    |
+| `payload.source.start_ts`      | 数值  | 源事务的开始 TSO。仅在启用 `debezium-include-start-ts` 或 `[sink.debezium] include-start-ts` 时出现。原始 uint64 PD TSO，不是毫秒时间戳。 |
 | `payload.source.db`     | 字符串   | 事件发生的数据库的名称。                    |
 | `payload.source.table`     | 字符串  |  事件发生的数据表的名称。                   |
 | `schema.fields`     | JSON   |  `payload` 中各个字段的类型信息，包括对应行数据变更前后 schema 的信息。      |

--- a/ticdc/ticdc-debezium.md
+++ b/ticdc/ticdc-debezium.md
@@ -25,9 +25,11 @@ cdc cli changefeed create --server=http://127.0.0.1:8300 --changefeed-id="kafka-
 
 Debezium 输出格式中包含当前行的 Schema 信息，以便下游消费者更好地理解当前行的数据结构。对于不需要输出 Schema 信息的场景，也可以通过在 changefeed 的配置文件或者 `sink-uri` 中将 `debezium-disable-schema` 参数设置为 `true` 来关闭 Schema 信息的输出。
 
-此外，Debezium 原有格式中并不包含 TiDB 专有的 `CommitTS` 事务唯一标识等重要字段。为了保证数据的完整性，TiCDC 在 Debezium 格式中增加了 `CommitTs` 和 `ClusterID` 两个字段，用于标识 TiDB 数据变更的相关信息。
+TiCDC 在 Debezium 的 `source` 元数据中增加了 `commit_ts` 和 `cluster_id` 字段，分别表示每条变更的提交时间戳和来源集群。
 
-### 包含事务开始 TSO <span class="version-mark">从 v8.5.9 版本开始引入</span>
+### 包含事务开始 TSO
+
+该选项需要使用 [TiCDC 新架构](/ticdc/ticdc-architecture.md)。
 
 默认情况下，Debezium JSON DML 消息包含 `source.commit_ts`，但不包含事务开始 TSO。你可以选择仅在 DML 行事件中包含 `source.start_ts`（源事务开始时的原始 PD TSO）。该选项默认关闭。
 
@@ -35,7 +37,7 @@ Debezium 输出格式中包含当前行的 Schema 信息，以便下游消费者
 
 - 在 `sink-uri` 中：
 
-    ```
+    ```text
     kafka://127.0.0.1:9092/topic-name?protocol=debezium&debezium-include-start-ts=true
     ```
 
@@ -50,21 +52,23 @@ Debezium 输出格式中包含当前行的 Schema 信息，以便下游消费者
 
 开启该选项后：
 
-- DML 消息的 value 会在 `commit_ts` 旁增加整型字段 `source.start_ts`，JSON schema 将该字段声明为 `int64`。
-- DDL 事件、WATERMARK 事件、key 消息和 Debezium Avro 不受影响。将该选项与 Debezium Avro 协议一起使用会被拒绝。
-- 如需回滚，关闭该选项即可。关闭期间产出的消息与此前格式保持兼容。
+- DML 消息的 Value 会增加 JSON 整数字段 `source.start_ts`，与 `source.commit_ts` 同级。启用 schema 输出时，JSON schema 将 `source.start_ts` 声明为 `int64`。
+- DDL 事件、WATERMARK 事件和 Key 消息不包含 `start_ts`。在 `debezium` 以外的协议（包括 `debezium-avro`）中开启该选项会被拒绝。
+- 如需停止输出 `start_ts`，关闭该选项即可。关闭后产生的消息不再包含该字段及其 schema 声明。
 
 > **注意：**
 >
-> `start_ts` 是原始的 uint64 PD TSO，不是毫秒时间戳。消费者必须将其作为 64 位整数或十进制字符串处理。不要将其解析为 JavaScript `Number` 或 IEEE-754 `float64`，后者无法精确表示 18 位 TSO。
+> `start_ts` 是以 JSON 整数编码的原始 PD TSO，不是毫秒时间戳。TiCDC 使用 `uint64` 存储 TSO，而 Debezium schema 将该字段声明为 `int64`，因此遵循该 schema 的消费者受有符号 64 位整数范围限制（最大值为 `9223372036854775807`）。请使用能够保留整数精度的解析器直接解析 JSON 整数，或将其原始十进制数字保留为字符串。不要先转换为 JavaScript `Number` 或 IEEE 754 `float64`：大于 `2^53 - 1` 的整数可能丢失精度。
 
 开启该选项后，`source` 字段类似如下：
 
 ```json
-"source": {
-    "commit_ts": 447507027004751877,
-    "start_ts": 447507027004751800,
-    "cluster_id": "default"
+{
+    "source": {
+        "commit_ts": 447507027004751877,
+        "start_ts": 447507027004751800,
+        "cluster_id": "default"
+    }
 }
 ```
 
@@ -611,7 +615,7 @@ Key 中的字段只包含主键或唯一索引列。字段解释如下：
 | `payload.before`    | JSON   | 这条事件语句变更前的数据值。对于 `"c"` 事件，`before` 字段的值为 `null`。  |
 | `payload.after`     | JSON   | 这条事件语句变更后的数据值。对于 `"d"` 事件，`after` 字段的值为 `null`。   |
 | `payload.source.commit_ts`     | 数值  | 该事件的 `CommitTs` 值。                    |
-| `payload.source.start_ts`      | 数值  | 源事务的开始 TSO。仅在启用 `debezium-include-start-ts` 或 `[sink.debezium] include-start-ts` 时出现。原始 uint64 PD TSO，不是毫秒时间戳。 |
+| `payload.source.start_ts` | JSON 整数（schema 中为 `int64`） | 源事务的原始 PD TSO。仅在启用 `debezium-include-start-ts` 或 `[sink.debezium] include-start-ts` 时出现。解析时需要保留整数精度，详见[包含事务开始 TSO](#包含事务开始-tso)。 |
 | `payload.source.db`     | 字符串   | 事件发生的数据库的名称。                    |
 | `payload.source.table`     | 字符串  |  事件发生的数据表的名称。                   |
 | `schema.fields`     | JSON   |  `payload` 中各个字段的类型信息，包括对应行数据变更前后 schema 的信息。      |

--- a/ticdc/ticdc-open-api-v2.md
+++ b/ticdc/ticdc-open-api-v2.md
@@ -371,6 +371,7 @@ curl -X GET http://127.0.0.1:8300/api/v2/health
 | 参数名                | 说明                                                                 |
 |:-------------------|:-------------------------------------------------------------------|
 | `output_old_value` | `BOOLEAN` 类型，是否输出行数据更改前的值。默认值为 `true`。关闭后，Update 事件不会输出 "before" 字段的数据。 |
+| `include_start_ts` | `BOOLEAN` 类型。从 v8.5.9 开始引入。控制 Debezium JSON DML 消息是否包含 `source.start_ts`（源事务的原始 PD TSO）。默认值为 `false`。 |
 
 ### 使用样例
 

--- a/ticdc/ticdc-open-api-v2.md
+++ b/ticdc/ticdc-open-api-v2.md
@@ -315,6 +315,7 @@ curl -X GET http://127.0.0.1:8300/api/v2/health
 | `cloud_storage_config`        | storage sink 配置。（非必选）                                                                              |
 | `open`                        | Open Protocol 配置。（非必选）                                                                             |
 | `debezium`                    | Debezium Protocol 配置。（非必选）                                                                             |
+| `simple` | Simple 协议配置。（非必选） |
 
 `sink.column_selectors` 是一个数组，元素参数说明如下：
 
@@ -371,7 +372,13 @@ curl -X GET http://127.0.0.1:8300/api/v2/health
 | 参数名                | 说明                                                                 |
 |:-------------------|:-------------------------------------------------------------------|
 | `output_old_value` | `BOOLEAN` 类型，是否输出行数据更改前的值。默认值为 `true`。关闭后，Update 事件不会输出 "before" 字段的数据。 |
-| `include_start_ts` | `BOOLEAN` 类型。从 v8.5.9 开始引入。控制 Debezium JSON DML 消息是否包含 `source.start_ts`（源事务的原始 PD TSO）。默认值为 `false`。 |
+| `include_start_ts` | `BOOLEAN` 类型，默认值为 `false`。需要使用 TiCDC 新架构和 `protocol=debezium` 的 MQ sink。开启后，Debezium JSON DML 消息包含 `source.start_ts`。显式指定的 URI 参数 `debezium-include-start-ts` 优先于该配置项，包括使用 `false` 覆盖 `true`。在其他协议（包括 `debezium-avro`）中开启该选项会被拒绝。 |
+
+`sink.simple` 参数说明如下：
+
+| 参数名 | 说明 |
+|:-------|:-----|
+| `include_start_ts` | `BOOLEAN` 类型，默认值为 `false`。需要使用 TiCDC 新架构，以及 `protocol=simple` 和 JSON 编码的 MQ sink。开启后，DML 消息包含顶层整数字段 `startTs`。显式指定的 URI 参数 `simple-include-start-ts` 优先于该配置项，包括使用 `false` 覆盖 `true`。在其他协议或 `encoding-format=avro` 下开启该选项会被拒绝。 |
 
 ### 使用样例
 

--- a/ticdc/ticdc-simple-protocol.md
+++ b/ticdc/ticdc-simple-protocol.md
@@ -46,6 +46,54 @@ send-bootstrap-to-all-partition = true
 encoding-format = "json"
 ```
 
+### 包含事务开始 TSO
+
+使用 [TiCDC 新架构](/ticdc/ticdc-architecture.md)时，你可以在 Simple JSON DML 消息中包含源事务的原始开始 TSO。该选项默认关闭，可以通过以下任一方式开启：
+
+- 在 `sink-uri` 中：
+
+    ```text
+    kafka://127.0.0.1:9092/topic-name?protocol=simple&encoding-format=json&simple-include-start-ts=true
+    ```
+
+- 在 changefeed 配置文件中：
+
+    ```toml
+    [sink]
+    protocol = "simple"
+
+    [sink.simple]
+    include-start-ts = true
+    ```
+
+显式指定的 URI 参数优先于配置文件。例如，`simple-include-start-ts=false` 会覆盖 `[sink.simple] include-start-ts = true`。
+
+开启后，`INSERT`、`UPDATE` 和 `DELETE` 消息会包含顶层 JSON 整数字段 `startTs`。DDL、`BOOTSTRAP` 和 `WATERMARK` 消息不包含该字段。在其他协议或 `encoding-format=avro` 下开启该选项会被拒绝。关闭该选项后，后续消息不再包含 `startTs`。
+
+以下是开启该选项后的 `INSERT` 消息示例：
+
+```json
+{
+   "version":1,
+   "database":"simple",
+   "table":"user",
+   "tableID":148,
+   "type":"INSERT",
+   "commitTs":447984084414103554,
+   "startTs":447984084414103550,
+   "buildTs":1708923662983,
+   "schemaVersion":447984074911121426,
+   "data":{
+      "id":"1",
+      "name":"John Doe"
+   }
+}
+```
+
+> **注意：**
+>
+> `startTs` 是原始 `uint64` PD TSO，不是毫秒时间戳。请使用能够保留整数精度的 JSON 解析器直接解析，或将原始十进制数字保留为字符串。不要先解析为 JavaScript `Number` 或 IEEE 754 `float64`：大于 `2^53 - 1` 的整数可能丢失精度。
+
 ## Message 类型
 
 TiCDC Simple Protocol 支持如下 Message 类型：
@@ -74,7 +122,7 @@ DML：
 
 ## Message 格式
 
-在 Simple Protocol 中，每一个 Message 都只会包含一个事件。当前 Simple Protocol 支持把消息编码为 JSON 格式和 Avro 格式。本文将以 JSON 格式为例进行说明。对于 Avro 格式的消息，其字段和含义与 JSON 格式的消息一致，只是编码格式不同，格式详见 [Simple Protocol Avro Schema](https://github.com/pingcap/tiflow/blob/master/pkg/sink/codec/simple/message.json)。
+在 Simple Protocol 中，每一个 Message 都只会包含一个事件。当前 Simple Protocol 支持把消息编码为 JSON 格式和 Avro 格式。本文将以 JSON 格式为例进行说明。除仅用于 JSON 的可选字段 `startTs` 外，Avro 消息的字段和含义与 JSON 消息一致，只是编码格式不同，格式详见 [Simple Protocol Avro Schema](https://github.com/pingcap/tiflow/blob/master/pkg/sink/codec/simple/message.json)。
 
 ### DDL
 
@@ -241,6 +289,8 @@ TiCDC 会把一个 DDL 事件编码成如下的 JSON 格式：
 
 ### DML
 
+以下示例使用默认配置，不包含 `startTs`。如需在 JSON DML 消息中输出该字段，详见[包含事务开始 TSO](#包含事务开始-tso)。
+
 #### INSERT
 
 TiCDC 会把一个 `INSERT` 事件编码成如下的 JSON 格式：
@@ -274,6 +324,7 @@ TiCDC 会把一个 `INSERT` 事件编码成如下的 JSON 格式：
 | `tableID`       | Number    | 表的 ID。                                                                  |
 | `type`          | String | DML 事件类型，包括 `INSERT`、`UPDATE` 和 `DELETE`。                              |
 | `commitTs`      | Number    | 该 DML 在上游执行结束时的 `commitTs`。                              |
+| `startTs` | JSON 整数 (`uint64`) | 可选，源事务的原始 PD TSO。仅在启用[事务开始 TSO 输出](#包含事务开始-tso)时出现；解析时需要保留整数精度。 |
 | `buildTs`       | Number    | 该消息在 TiCDC 内部被编码成功时的 UNIX 时间戳。                            |
 | `schemaVersion` | Number    | 编码该 DML 消息时所使用表的 schema 版本号。                                |
 | `data`          | Object | 插入的数据，字段名为列名，字段值为列值。                                   |
@@ -319,6 +370,7 @@ TiCDC 会把一个 `UPDATE` 事件编码成如下的 JSON 格式：
 | `tableID`       | Number    | 表的 ID。                                                                  |
 | `type`          | String | DML 事件类型，包括 `INSERT`、`UPDATE` 和 `DELETE`。                              |
 | `commitTs`      | Number    | 该 DML 在上游执行结束时的 `commitTs`。                         |
+| `startTs` | JSON 整数 (`uint64`) | 可选，源事务的原始 PD TSO。仅在启用[事务开始 TSO 输出](#包含事务开始-tso)时出现；解析时需要保留整数精度。 |
 | `buildTs`       | Number    | 该消息在 TiCDC 内部被编码成功时的 UNIX 时间戳。                            |
 | `schemaVersion` | Number    | 编码该 DML 消息时所使用表的 schema 版本号。                                |
 | `data`          | Object | 更新后的数据，字段名为列名，字段值为列值。                                 |
@@ -359,6 +411,7 @@ TiCDC 会把一个 `DELETE` 事件编码成如下的 JSON 格式：
 | `tableID`       | Number    | 表的 ID。                                                                  |
 | `type`          | String | DML 事件类型，包括 `INSERT`、`UPDATE` 和 `DELETE`。                              |
 | `commitTs`      | Number    | 该 DML 在上游执行结束的 `commitTs`。                                         |
+| `startTs` | JSON 整数 (`uint64`) | 可选，源事务的原始 PD TSO。仅在启用[事务开始 TSO 输出](#包含事务开始-tso)时出现；解析时需要保留整数精度。 |
 | `buildTs`       | Number    | 该消息在 TiCDC 内部被编码成功时的 UNIX 时间戳。                            |
 | `schemaVersion` | Number    | 编码该 DML 消息时所使用表的 schema 版本号。                                  |
 | `old`           | Object | 删除的数据，字段名为列名，字段值为列值。                                   |

--- a/ticdc/ticdc-sink-to-kafka.md
+++ b/ticdc/ticdc-sink-to-kafka.md
@@ -83,6 +83,7 @@ URI 中可配置的的参数如下：
 | `compression`        | 设置发送消息时使用的压缩算法（可选值为 `none`、`lz4`、`gzip`、`snappy` 和 `zstd`，默认值为 `none`）。注意 Snappy 压缩文件必须遵循[官方 Snappy 格式](https://github.com/google/snappy)。不支持其他非官方压缩格式。|
 | `auto-create-topic` | 当传入的 `topic-name` 在 Kafka 集群不存在时，TiCDC 是否要自动创建该 topic（可选，默认值 `true`）。 |
 | `enable-tidb-extension` | 可选，默认值是 `false`。当输出协议为 `canal-json` 时，如果该值为 `true`，TiCDC 会发送 [WATERMARK 事件](/ticdc/ticdc-canal-json.md#watermark-event)，并在 Kafka 消息中添加 TiDB 扩展字段。从 6.1.0 开始，该参数也可以和输出协议 `avro` 一起使用。如果该值为 `true`，TiCDC 会在 Kafka 消息中添加[三个 TiDB 扩展字段](/ticdc/ticdc-avro-protocol.md#tidb-扩展字段)。|
+| `debezium-include-start-ts` | 可选，从 v8.5.9 开始引入，默认值是 `false`。仅当 `protocol` 为 `debezium` 时生效。如果该值为 `true`，TiCDC 会在 Debezium JSON DML 消息中添加 `source.start_ts`（源事务的原始 PD TSO）。显式指定的 URI 参数优先于配置文件中的 `[sink.debezium] include-start-ts`。该选项与 Debezium Avro 一起使用会被拒绝。详情请参考 [TiCDC Debezium Protocol](/ticdc/ticdc-debezium.md#包含事务开始-tso)。 |
 | `max-batch-size` |  从 v4.0.9 开始引入。当消息协议支持把多条变更记录输出至一条 Kafka 消息时，该参数用于指定这一条 Kafka 消息中变更记录的最多数量。目前，仅当 Kafka 消息的 `protocol` 为 `open-protocol` 时有效（可选，默认值 `16`）。|
 | `enable-tls` | 连接下游 Kafka 实例是否使用 TLS（可选，默认值 `false`）。 |
 | `ca`       | 连接下游 Kafka 实例所需的 CA 证书文件路径（可选）。 |

--- a/ticdc/ticdc-sink-to-kafka.md
+++ b/ticdc/ticdc-sink-to-kafka.md
@@ -83,7 +83,8 @@ URI 中可配置的的参数如下：
 | `compression`        | 设置发送消息时使用的压缩算法（可选值为 `none`、`lz4`、`gzip`、`snappy` 和 `zstd`，默认值为 `none`）。注意 Snappy 压缩文件必须遵循[官方 Snappy 格式](https://github.com/google/snappy)。不支持其他非官方压缩格式。|
 | `auto-create-topic` | 当传入的 `topic-name` 在 Kafka 集群不存在时，TiCDC 是否要自动创建该 topic（可选，默认值 `true`）。 |
 | `enable-tidb-extension` | 可选，默认值是 `false`。当输出协议为 `canal-json` 时，如果该值为 `true`，TiCDC 会发送 [WATERMARK 事件](/ticdc/ticdc-canal-json.md#watermark-event)，并在 Kafka 消息中添加 TiDB 扩展字段。从 6.1.0 开始，该参数也可以和输出协议 `avro` 一起使用。如果该值为 `true`，TiCDC 会在 Kafka 消息中添加[三个 TiDB 扩展字段](/ticdc/ticdc-avro-protocol.md#tidb-扩展字段)。|
-| `debezium-include-start-ts` | 可选，从 v8.5.9 开始引入，默认值是 `false`。仅当 `protocol` 为 `debezium` 时生效。如果该值为 `true`，TiCDC 会在 Debezium JSON DML 消息中添加 `source.start_ts`（源事务的原始 PD TSO）。显式指定的 URI 参数优先于配置文件中的 `[sink.debezium] include-start-ts`。该选项与 Debezium Avro 一起使用会被拒绝。详情请参考 [TiCDC Debezium Protocol](/ticdc/ticdc-debezium.md#包含事务开始-tso)。 |
+| `debezium-include-start-ts` | 可选，默认值为 `false`。需要使用 TiCDC 新架构和 `protocol=debezium`。开启后，Debezium JSON DML 消息包含 `source.start_ts`（源事务的 TSO）。显式指定的 URI 参数优先于 `[sink.debezium] include-start-ts`，包括使用 `false` 覆盖 `true`。在其他协议（包括 `debezium-avro`）中开启该选项会被拒绝。详见 [TiCDC Debezium Protocol](/ticdc/ticdc-debezium.md#包含事务开始-tso)。 |
+| `simple-include-start-ts` | 可选，默认值为 `false`。需要使用 TiCDC 新架构、`protocol=simple` 和 JSON 编码。开启后，DML 消息包含顶层整数字段 `startTs`（源事务的 TSO）。显式指定的 URI 参数优先于 `[sink.simple] include-start-ts`，包括使用 `false` 覆盖 `true`。在其他协议或 `encoding-format=avro` 下开启该选项会被拒绝。详见 [TiCDC Simple Protocol](/ticdc/ticdc-simple-protocol.md#包含事务开始-tso)。 |
 | `max-batch-size` |  从 v4.0.9 开始引入。当消息协议支持把多条变更记录输出至一条 Kafka 消息时，该参数用于指定这一条 Kafka 消息中变更记录的最多数量。目前，仅当 Kafka 消息的 `protocol` 为 `open-protocol` 时有效（可选，默认值 `16`）。|
 | `enable-tls` | 连接下游 Kafka 实例是否使用 TLS（可选，默认值 `false`）。 |
 | `ca`       | 连接下游 Kafka 实例所需的 CA 证书文件路径（可选）。 |


### PR DESCRIPTION
<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->
<!--
We provide several doc templates for you to use to create documentation that aligns with our style.
Please check out these templates before you submit the pull request:
https://github.com/pingcap/docs/tree/master/resources/doc-templates
-->

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

Document the optional source transaction TSO in Debezium JSON (`source.start_ts`) and Simple JSON (`startTs`) for the new TiCDC architecture. Both options are disabled by default and let consumers correlate row changes with their source transaction.

- Cover URI and TOML configuration, explicit URI precedence (including `false` overriding `true`), DML-only scope, format restrictions, and integer precision.
- Add Simple to the protocol, Kafka sink, changefeed configuration, and OpenAPI v2 references; preserve the default message examples.
- Clarify the Debezium JSON integer versus `int64` schema representation and complete its OpenAPI configuration contract.
- Target master only. Remove the unconfirmed v8.5.9 availability claim; the release-8.5 implementation cherry-pick is still open.

Validation: Markdown lint and internal link checks for all five changed pages; new JSON/TOML examples parse successfully; behavior checked against the implementation and tests in the linked code PRs.

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from: https://github.com/pingcap/docs/pull/23614
- Other reference link(s):
  - https://github.com/pingcap/ticdc/pull/5903 (Debezium implementation, merged)
  - https://github.com/pingcap/ticdc/pull/6143 (Simple implementation, merged)
  - https://github.com/pingcap/ticdc/issues/6106 (Simple protocol contract)
  - https://github.com/pingcap/ticdc/pull/6039 (release-8.5 cherry-pick, still open)

### AI agent involvement

- [x] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label. -->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * Debezium JSON DML 消息支持可选输出源事务开始 TSO：`source.start_ts`。
  * Simple JSON DML 消息支持可选输出顶层 `startTs` 字段。
  * 可通过配置或 URI 参数启用，URI 参数优先于配置文件；默认关闭。
  * 仅适用于对应的 JSON 消息，Avro 或不兼容协议下启用将被拒绝。

* **文档**
  * 补充配置方式、消息示例、字段说明、兼容性限制及 TSO 精度注意事项。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->