### PR TITLE
Document `tidb_query_cop_store_limit` variable

### DIFF
--- a/system-variables.md
+++ b/system-variables.md
@@ -5056,10 +5056,10 @@ EXPLAIN FORMAT='brief' SELECT COUNT(1) FROM t WHERE a = 1 AND b IS NOT NULL;
 - 类型：整数型
 - 默认值：`15`
 - 范围：`[0, 256]`
-- 这个变量用于限制单条查询语句发送到每个 TiKV Store 的并发 Coprocessor 请求尝试数。该限制对同一语句创建的多个 DistSQL 请求生效，并且每次重试都会重新按照实际目标 TiKV Store 进行限制。
-- 当该变量设置为 `0` 时，不启用查询级别的 TiKV Store 并发限制；当设置为大于 `0` 的值时，单条查询语句对每个 TiKV Store 最多允许相应数量的 Coprocessor 请求尝试同时执行。
-- 该变量不会覆盖 [`tidb_distsql_scan_concurrency`](#tidb_distsql_scan_concurrency) 的设置。`tidb_distsql_scan_concurrency` 控制单个 DistSQL 请求的扫描 Worker 并发度，而本变量控制单条查询语句对每个 TiKV Store 的 Coprocessor 请求尝试并发度。单条查询语句包含多个 DistSQL 请求时，本变量仍对这些请求共享生效。
-- 将该变量设置为较小的值可能降低 TiKV Store 的瞬时压力，但也可能增加查询延迟。
+- 这个变量用于限制单条查询语句对每个 TiKV Store 的并发 Coprocessor 请求尝试数。
+- 当该变量设置为 `0` 时，禁用查询级别的按 Store 限流；设置为大于 `0` 的值 `N` 时，单条查询语句对每个 TiKV Store 最多允许 `N` 个 Coprocessor 请求尝试同时执行。
+- 该变量不会覆盖 [`tidb_distsql_scan_concurrency`](#tidb_distsql_scan_concurrency)。后者控制单个 DistSQL 请求的扫描并发度，本变量控制单条查询语句在每个 TiKV Store 上的物理请求并发度。单条查询语句包含多个 DistSQL 请求时，本变量仍对这些请求共享生效。
+- 将该变量设置为较小的值可以降低 TiKV Store 的瞬时压力，但可能增加查询延迟。
 
 ### `tidb_query_log_max_len`
 

--- a/system-variables.md
+++ b/system-variables.md
@@ -5048,7 +5048,7 @@ EXPLAIN FORMAT='brief' SELECT COUNT(1) FROM t WHERE a = 1 AND b IS NOT NULL;
 - 这个变量用来设置 `Projection` 算子的并发度。
 - 默认值 `-1` 表示使用 `tidb_executor_concurrency` 的值。
 
-### `tidb_query_cop_store_limit`
+### `tidb_query_cop_store_limit` <span class="version-mark">从 v9.0.0 版本开始引入</span>
 
 - 作用域：SESSION | GLOBAL
 - 是否持久化到集群：是
@@ -5058,7 +5058,7 @@ EXPLAIN FORMAT='brief' SELECT COUNT(1) FROM t WHERE a = 1 AND b IS NOT NULL;
 - 范围：`[0, 256]`
 - 这个变量用于限制单条查询语句发送到每个 TiKV Store 的并发 Coprocessor 请求尝试数。该限制对同一语句创建的多个 DistSQL 请求生效，并且每次重试都会重新按照实际目标 TiKV Store 进行限制。
 - 当该变量设置为 `0` 时，不启用查询级别的 TiKV Store 并发限制；当设置为大于 `0` 的值时，单条查询语句对每个 TiKV Store 最多允许相应数量的 Coprocessor 请求尝试同时执行。
-- 该变量只对 TiKV Coprocessor 请求生效，不影响 TiFlash 请求。它与 [`tidb_distsql_scan_concurrency`](#tidb_distsql_scan_concurrency) 不同，后者控制单个 DistSQL 请求的扫描并发度。
+- 该变量不会覆盖 [`tidb_distsql_scan_concurrency`](#tidb_distsql_scan_concurrency) 的设置。`tidb_distsql_scan_concurrency` 控制单个 DistSQL 请求的扫描 Worker 并发度，而本变量控制单条查询语句对每个 TiKV Store 的 Coprocessor 请求尝试并发度。单条查询语句包含多个 DistSQL 请求时，本变量仍对这些请求共享生效。
 - 将该变量设置为较小的值可能降低 TiKV Store 的瞬时压力，但也可能增加查询延迟。
 
 ### `tidb_query_log_max_len`

--- a/system-variables.md
+++ b/system-variables.md
@@ -5048,6 +5048,19 @@ EXPLAIN FORMAT='brief' SELECT COUNT(1) FROM t WHERE a = 1 AND b IS NOT NULL;
 - 这个变量用来设置 `Projection` 算子的并发度。
 - 默认值 `-1` 表示使用 `tidb_executor_concurrency` 的值。
 
+### `tidb_query_cop_store_limit`
+
+- 作用域：SESSION | GLOBAL
+- 是否持久化到集群：是
+- 是否受 Hint [SET_VAR](/optimizer-hints.md#set_varvar_namevar_value) 控制：是
+- 类型：整数型
+- 默认值：`15`
+- 范围：`[0, 256]`
+- 这个变量用于限制单条查询语句发送到每个 TiKV Store 的并发 Coprocessor 请求尝试数。该限制对同一语句创建的多个 DistSQL 请求生效，并且每次重试都会重新按照实际目标 TiKV Store 进行限制。
+- 当该变量设置为 `0` 时，不启用查询级别的 TiKV Store 并发限制；当设置为大于 `0` 的值时，单条查询语句对每个 TiKV Store 最多允许相应数量的 Coprocessor 请求尝试同时执行。
+- 该变量只对 TiKV Coprocessor 请求生效，不影响 TiFlash 请求。它与 [`tidb_distsql_scan_concurrency`](#tidb_distsql_scan_concurrency) 不同，后者控制单个 DistSQL 请求的扫描并发度。
+- 将该变量设置为较小的值可能降低 TiKV Store 的瞬时压力，但也可能增加查询延迟。
+
 ### `tidb_query_log_max_len`
 
 - 作用域：GLOBAL


### PR DESCRIPTION
Added documentation for the `tidb_query_cop_store_limit` system variable, including its scope, persistence, type, default value, range, and behavior.

<!--Thanks for your contribution to TiDB documentation. Please answer the following questions.-->

### First-time contributors' checklist <!--Remove this section if you're not a first-time contributor.-->

- [x] I've signed the [**Contributor License Agreement**](https://cla.pingcap.net/pingcap/docs), which is required for the repository owners to accept my contribution.

### What is changed, added or deleted? (Required)

<!--Tell us what you did and why.-->

### Which TiDB version(s) do your changes apply to? (Required)

<!-- Fill in "x" in [] to tick the checkbox below.-->

**Tips for choosing the affected version(s):**

By default, **CHOOSE MASTER ONLY** so your changes will be applied to the next TiDB major or minor releases. If your PR involves a product feature behavior change or a compatibility change, **CHOOSE THE AFFECTED RELEASE BRANCH(ES) AND MASTER**.

For details, see [tips for choosing the affected versions (in Chinese)](https://github.com/pingcap/docs-cn/blob/master/CONTRIBUTING.md#版本选择指南).

- [x] master (the latest development version)
- [ ] v9.0 (TiDB 9.0 versions)
- [ ] v8.5 (TiDB 8.5 versions)
- [ ] v8.1 (TiDB 8.1 versions)
- [ ] v7.5 (TiDB 7.5 versions)
- [ ] v7.1 (TiDB 7.1 versions)
- [ ] v6.5 (TiDB 6.5 versions)

### What is the related PR or file link(s)?

<!--Reference link(s) will help reviewers review your PR quickly.-->

- This PR is translated from:
- Other reference link(s): https://github.com/pingcap/tidb/pull/69360

### AI agent involvement

- [ ] The changes in this PR were primarily made by an AI agent on behalf of the PR author.

### Do your changes match any of the following descriptions?

- [ ] Delete files
- [ ] Change aliases
- [ ] Need modification after applied to another branch <!-- If yes, please comment "/label version-specific-changes-required" below to trigger the bot to add the label.-->
- [ ] Might cause conflicts after applied to another branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **文档**
  - 新增系统变量 `tidb_query_cop_store_limit` 的说明。
  - 补充其 SESSION/GLOBAL 作用域、默认值 15、取值范围 `[0, 256]`、集群持久化及 `SET_VAR` Hint 支持。
  - 说明该变量对 TiKV Coprocessor 请求并发尝试数的限制，以及设置为 0 时禁用限制。
  - 明确其与扫描并发度设置的区别，以及不影响 TiFlash 请求。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->